### PR TITLE
Capture metadata files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ cwltool --print-dot DeriveArrayElementCoordinates.cwl | dot -Tsvg > DeriveArrayE
 ```
 
 Alternatively, use https://view.commonwl.org/ , e.g., see [this example](https://view.commonwl.org/workflows/github.com/gammasim/workflows/blob/prototype-DeriveArrayElementCoordinates/workflows/DeriveArrayElementCoordinates.cwl).
+
+## Developer Notes
+
+Following notes are unsorted, but probably useful for developement:
+
+1. Capture stdout of tools by using `cwltool --log-dir ./my-log-dir...` . This allow to find easier errors produced by the tools (otherwise reported errors are mostly that output is not found).

--- a/schemas/array_coordinates_UTM.schema.yml
+++ b/schemas/array_coordinates_UTM.schema.yml
@@ -49,6 +49,8 @@ schema:
             required: true
             type: double
             units: m
+            allowed_range:
+              min: 0.
             input_processing:
               - allow_nan
           - name: geo_code

--- a/tests/resources/test_derive_array_elements_coordinates.yml
+++ b/tests/resources/test_derive_array_elements_coordinates.yml
@@ -10,11 +10,11 @@ schema_input:
   description: |-
     Schema describing input data.
   location:
-    https://raw.githubusercontent.com/gammasim/workflows/prototype-DeriveArrayElementCoordinates/schemas/array_coordinates_UTM.schema.yml
+    https://raw.githubusercontent.com/gammasim/workflows/main/schemas/array_coordinates_UTM.schema.yml
 schema:
   class: File
   description: |-
     Schema describing output data
     (this should be known by the workflow and probably does not need to be provided in future).
   location:
-    https://raw.githubusercontent.com/gammasim/workflows/prototype-DeriveArrayElementCoordinates/schemas/array_coordinates.schema.yml
+    https://raw.githubusercontent.com/gammasim/workflows/main/schemas/array_coordinates.schema.yml

--- a/workflows/DeriveArrayElementCoordinates.cwl
+++ b/workflows/DeriveArrayElementCoordinates.cwl
@@ -27,7 +27,7 @@ inputs:
 outputs:
 
   - id: log_assert_input
-    type: File
+    type: File[]
     doc: |-
         Log file from assertion of input data.
     outputSource: assert_input_data/assertion_data
@@ -41,13 +41,13 @@ outputs:
   - id: log_derive_array_elements_coordinates
     doc: |-
         Log file from derivation of array element coordinates.
-    type: File
+    type: File[]
     outputSource: derive_array_elements_coordinates/derivation_data
 
   - id: log_assert_model_parameter
     doc: |-
         Log file from assertion of derived model parameter.
-    type: File
+    type: File[]
     outputSource: assert_model_parameter/assertion_data
 
 steps:

--- a/workflows/tools/assert_data.cwl
+++ b/workflows/tools/assert_data.cwl
@@ -46,9 +46,9 @@ outputs:
     - id: assertion_data
       doc: |-
         Additional data or logging output from this tool.
-      type: File
+      type: File[]
       outputBinding:
-        glob: $(inputs.name).log
+        glob: ["$(inputs.name).log", "simtools-output/*.metadata.yml"]
 
 stdout: $(inputs.name).log
 stderr: $(inputs.name).log

--- a/workflows/tools/derive_array_elements_coordinates.cwl
+++ b/workflows/tools/derive_array_elements_coordinates.cwl
@@ -36,9 +36,9 @@ outputs:
     - id: derivation_data
       doc: |-
         Additional data or logging output from this tool.
-      type: File
+      type: File[]
       outputBinding:
-        glob: "derivation_data.log"
+        glob: ["derivation_data.log", "simtools-output/*.metadata.yml"]
 
 stdout: derivation_data.log
 stderr: derivation_data.log


### PR DESCRIPTION
This (small) PR adds:

- capture metadata.yml files produced by simtools.
- corrects the URLs to testing files (pointed to an old branch)
- adds a developer notes section to the README, where hints on the peculiar behavior of cwltools can be collected