### PR TITLE
Adding parameter schemas

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Lint yml files
         run: |
-          find ./schemas -name "*.yml" -print0 | xargs -0 -I {} yamllint {}
+          find ./schemas -name "*.yml" -print0 | xargs -0 -I {} yamllint -d "{extends: relaxed, rules: {line-length: {max: 100}}}" {}
 
       - name: Lint CWL files
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,6 +13,10 @@ authors:
     family-names: Maier
     affiliation: DESY
     orcid: 'https://orcid.org/0000-0001-9868-4700'
+  - given-names: Konrad
+    family-names: Bernlöhr
+    affiliation: MPIK
+    orcid: 'https://orcid.org/0000-0001-8065-3252'
   - given-names: Orel
     family-names: Gueta
     orcid: 'https://orcid.org/0000-0002-9440-2398'

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -3,7 +3,7 @@
 This directory contains a descriptions of all simulation model parameters and of all input data required for the derivation and setting of simulation model parameters.
 The description includes (among others fields) name, type, format, applicable telescopes, and parameter description.
 
-The model parameter descriptions are derived from (and planned to be synchronized with) the [simtel\_array manual](https://www.mpi-hd.mpg.de/hfm/~bernlohr/sim_telarray).
+The model parameter descriptions are derived from (and planned to be synchronized with) the [sim_telarray manual](https://www.mpi-hd.mpg.de/hfm/~bernlohr/sim_telarray).
 
 The files are in human readable yaml format and follow a fixed [json-schema](https://json-schema.org/).
 The full description of the schema is in [jsonschema.yml](./jsonschema.yml), including plenty of comments.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,7 +1,9 @@
 # Schema files for description of simulation model parameters and input data
 
 This directory contains a descriptions of all simulation model parameters and of all input data required for the derivation and setting of simulation model parameters.
-The parameter description includes (among others fields) name, type, format, applicable telescopes, and parameter description.
+The description includes (among others fields) name, type, format, applicable telescopes, and parameter description.
+
+The model parameter descriptions are derived from (and planned to be synchronized with) the [simtel\_array manual](https://www.mpi-hd.mpg.de/hfm/~bernlohr/sim_telarray).
 
 The files are in human readable yaml format and follow a fixed [json-schema](https://json-schema.org/).
 The full description of the schema is in [jsonschema.yml](./jsonschema.yml), including plenty of comments.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -3,7 +3,7 @@
 This directory contains a descriptions of all simulation model parameters and of all input data required for the derivation and setting of simulation model parameters.
 The description includes (among others fields) name, type, format, applicable telescopes, and parameter description.
 
-The model parameter descriptions are derived from (and planned to be synchronized with) the [sim_telarray manual](https://www.mpi-hd.mpg.de/hfm/~bernlohr/sim_telarray).
+The model parameter descriptions are derived from (and planned to be synchronized with) the [sim_telarray manual](https://www.mpi-hd.mpg.de/hfm/~bernlohr/sim_telarray/).
 
 The files are in human readable yaml format and follow a fixed [json-schema](https://json-schema.org/).
 The full description of the schema is in [jsonschema.yml](./jsonschema.yml), including plenty of comments.

--- a/schemas/altitude.schema.yml
+++ b/schemas/altitude.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for altitude model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: altitude
+description: |-
+  Altitude above sea level of site centre.
+  Telescope z-positions are defined relative to this level
+  (taking `telescope_axes_height` into account).
+short_description: Altitude above sea level of site centre.
+data:
+  - type: double
+    units: m
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/schemas/asum_clipping.schema.yml
+++ b/schemas/asum_clipping.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for asum_clipping model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: asum_clipping
+description: |-
+  The amplitude level at which the signal from each pixel
+  (after optional shaping) is clipped for its contribution
+  to the analog sum trigger.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    default: 0.0
+    units: mV
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==AnalogSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/asum_offset.schema.yml
+++ b/schemas/asum_offset.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for asum_offset model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: asum_offset
+description: Offset in time where shaping convolution is done.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    default: 0.0
+    units: ns
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==AnalogSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/asum_shaping.schema.yml
+++ b/schemas/asum_shaping.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for asum_shaping model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: asum_shaping
+description: |-
+  Shaping (convolution) parameters for an input photo detector signal to the
+  resulting signal from which an analog-sum trigger decision may be derived.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: datatable
+    table_columns:
+      - name: time
+        description: Time steps.
+        required: true
+        units: dimensionless
+        type: double
+      - name: shape
+        description: Shaping factor.
+        required: true
+        units: dimensionless
+        type: double
+    condition: default_trigger==AnalogSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/asum_threshold.schema.yml
+++ b/schemas/asum_threshold.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for asum_threshold model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: asum_threshold
+description: |-
+  The amplitude level above which an analog sum leads to a telescope
+  trigger.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    default: 0.0
+    units: mV
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==AnalogSum
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTriggerThresholdsFromRateScan
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/atmospheric_profile.schema.yml
+++ b/schemas/atmospheric_profile.schema.yml
@@ -1,0 +1,55 @@
+%YAML 1.2
+---
+title: Schema for atmospheric_profile model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: atmospheric_profile
+developer_note: TODO - clarify if steps in and range of altitude are fixed.
+description: Density, thickness, and index of refraction as function of altitude.
+data:
+  - type: datatable
+    table_columns:
+      - name: altitude
+        description: Altitude above sea level.
+        required: true
+        units: km
+        type: double
+        required_range:
+          min: 0.0
+          max: 120.0
+      - name: density
+        description: Density of air at given altitude.
+        required: true
+        units: g/cm**3
+        type: double
+      - name: thickness
+        description: Thickness of air at given altitude.
+        required: true
+        units: g/cm**2
+        type: double
+      - name: refractive_index
+        description: Refractive index (n-1) of air at given altitude.
+        required: true
+        units: dimensionless
+        type: double
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateAtmosphericModel
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: corsika
+  - name: sim_telarray

--- a/schemas/atmospheric_transmission.schema.yml
+++ b/schemas/atmospheric_transmission.schema.yml
@@ -1,0 +1,63 @@
+%YAML 1.2
+---
+title: Schema for atmospheric_transmission model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: atmospheric_transmission
+developer_note: |-
+  TODO - crosscheck required range
+  This is a 3D table containing extinction vs altitude
+  vs wavelength values.
+description: |-
+  Optical thickness as a function of photon emission altitude
+  and wavelength.
+data:
+  - type: datatable
+    table_columns:
+      - name: wavelength
+        description: Wavelength.
+        required: true
+        units: nm
+        type: double
+        required_range:
+          min: 200.0
+          max: 700.0
+        column_type: independent
+      - name: altitude
+        description: Altitude above sea level.
+        required: true
+        units: km
+        type: double
+        required_range:
+          min: 0.0
+          max: 100.0
+        column_type: independent
+      - name: extinction
+        description: Extinction coefficient.
+        required: true
+        units: dimensionless
+        type: double
+        allowed_range:
+          min: 0.0
+        column_type: dependent
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateAtmosphericModel
+    - ValidateTelescopeSimulationModel
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+source:
+  - Calibration
+simulation_software:
+  - name: corsika
+  - name: sim_telarray

--- a/schemas/axes_offsets.schema.yml
+++ b/schemas/axes_offsets.schema.yml
@@ -1,0 +1,49 @@
+%YAML 1.2
+---
+title: Schema for axes_offsets model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: axes_offsets
+description: |-
+  Geometric offsets to be used in case that the azimuth, altitude, and
+  optical axes do not intersect at the reference point (the center of
+  the fiducial sphere in CORSIKA simulations). If both
+  values are non-zero but equal, the optical axis coincides with the
+  azimuth axis for vertical pointing.
+short_description: |-
+  Geometric offsets to be used in case that the azimuth, altitude,
+  and optical axes do not intersect at the reference point.
+data:
+  - type: double
+    units: cm
+    description: |-
+      Horizontal offset between the (vertical) azimuth axis and the
+      (horizontal) altitude rotation axis. A positive value corresponds
+      to an altitude axis towards the reflector. Altitude axis is on
+      the optical axis, if the second parameter is zero.
+  - type: double
+    units: cm
+    description: |-
+      Displacement perpendicular to the optical axis and the altitude
+      axis of the altitude rotation axis w.r.t to the reflector.
+      If the altitude axis is on the optical axis, the second parameter
+      is zero.
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/camera_body_diameter.schema.yml
+++ b/schemas/camera_body_diameter.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for camera_body_diameter model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: camera_body_diameter
+description: |-
+  Diameter of camera body (used to account for effects of shadowing).
+  Flat-to-flat for square and hexagonal shapes.
+data:
+  - type: double
+    units: cm
+    default: 160.0
+    allowed_range:
+      min: 0.0
+      max: 1000.0
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeShadowingParameters
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeShadowing
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/camera_body_shape.schema.yml
+++ b/schemas/camera_body_shape.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for camera_body_shape model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: camera_body_shape
+description: |-
+  Code for the shape of the camera,
+  \begin{itemize}
+  \item[$\circ$] 0 -- circular (default);
+  \item[$\circ$] 1 or 3 -- hexagonal;
+  \item[$\circ$] 2 -- square.
+  \end{itemize}
+  This shape is used only for the estimation of the shadowing.
+short_description: Camera body shape parameter (used to account for effects of shadowing).
+data:
+  - type: uint
+    units: dimensionless
+    allowed_range:
+      min: 0
+      max: 3
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeShadowingParameters
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/camera_config_pixel.schema.yml
+++ b/schemas/camera_config_pixel.schema.yml
@@ -1,0 +1,153 @@
+%YAML 1.2
+---
+title: Schema for camera_config_pixel model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: camera_config_pixel
+developer_note: |-
+  Part of sim_telarray camera_config_file (parameter Pixel).
+  The entries of pixel_type_id depend on the values provided by
+  camera_config_pixel_type.
+description: |-
+  Definition of pixel types, positions, status (on/off), relative gain
+  (w.r.t the provided gain) and quantum/photodetector efficiency
+  scaling (scale the provided quantum/photodetector efficiency distribution,
+  ignoring wavelength dependence).
+data:
+  - type: datatable
+    table_columns:
+      - name: pixel_id
+        type: uint
+        description: Pixel number (starting at 0)
+        required: true
+        units: dimensionless
+      - name: pixel_type_id
+        type: uint
+        description: Pixel type ID (see definition in pixel_type)
+        required: true
+        units: dimensionless
+      - name: position_x
+        description: Projected pixel x coordinate (in cm) before camera rotation.
+        type: double
+        units: cm
+        required: true
+      - name: position_y
+        description: Projected pixel y coordinate (in cm) before camera rotation.
+        type: double
+        units: cm
+        required: true
+      - name: module_number
+        description: |-
+          Module number to which the pixel belongs.
+          Defines geometry and is used e.g. for pixel alignment with
+          PIXELS_PARALLEL=2)
+        type: uint
+        units: dimensionless
+        required: false
+        default: 0
+      - name: board_number
+        description: Board number to which the pixel belongs.
+        type: uint
+        units: dimensionless
+        required: false
+        default: 0
+      - name: channel_number
+        description: |-
+          Input channel on electronic board; may be used in
+          future version for electronic cross-talk.
+        type: uint
+        units: dimensionless
+        required: false
+        default: 0
+      - name: module_id
+        developer_note: Required to be a hex number in sim_telarray
+        description: |-
+          Module id to which the pixel belongs.
+          If a module is swapped into a different place in the camera, its
+          module number (defined by geometry) would change, along with all
+          pixel coordinates, but the module ID would remain.
+          Not currently used. Should be hexadecimal, starting with 0x.
+        type: string
+        units: dimensionless
+        required: false
+        default: 0
+      - name: onflag
+        description: Turn on or off this pixel
+        type: boolean
+        default: true
+        required: false
+        units: dimensionless
+      - name: qe_relative
+        description: |-
+          Scaling factor of the Quantum or photon-detection efficiency of
+          this pixel. This scales the provided QE distribution without
+          changing the wavelength dependence before any random fluctuations
+          are applied.
+        type: double
+        default: 1.0
+        required: false
+        units: dimensionless
+      - name: gain_relative
+        description: |-
+          Signal gain or amplification in pixel relative to average
+          before any random fluctuations are applied.
+        type: double
+        default: 1.0
+        required: false
+        units: dimensionless
+      - name: d_z
+        description: |-
+          Shift of pixel height w.r.t. nominal focal surface shape
+          (or module) in centimeters, positive towards the infalling light.
+          No shift is needed where pixels are aligned module-wise.
+        type: double
+        default: 0.0
+        required: false
+        units: dimensionless
+      - name: pixel_rotation
+        description: Pixel rotation angle
+        type: double
+        units: deg
+        default: 0.0
+        required: false
+      - name: n_x
+        developer_note: Must be zero for pixels_parallel==1 or pixels_parallel==2.
+        description: |-
+          X component of non-standard pointing direction of
+          pixel axis is indicated by vector (Nx, Ny, 1.0).
+        type: double
+        units: deg
+        default: 0.0
+        required: false
+      - name: n_y
+        developer_note: Must be zero for pixels_parallel==1 or pixels_parallel==2.
+        description: |-
+          Y component of non-standard pointing direction of
+          pixel axis is indicated by vector (Nx, Ny, 1.0).
+        type: double
+        units: deg
+        default: 0.0
+        required: false
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateCameraGeometry
+    - ValidatePixelStatus
+    - ValidateCameraGainsAndEfficiency
+source:
+  - Initial instrument setup
+  - Calibration
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/camera_config_pixel_type.schema.yml
+++ b/schemas/camera_config_pixel_type.schema.yml
@@ -1,0 +1,107 @@
+%YAML 1.2
+---
+title: Schema for camera_config_pixel_type model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: camera_config_pixel_type
+developer_note: Part of sim_telarray camera_config_file (parameter PixType).
+description: |-
+  Defines a pixel type, including the geometrical shape (circular, square,
+  hexagonal) of the pixel border and of the visible cathode, the size,
+  the depth of light collecting elements (funnels) and their reflectivity
+  (as a number) or angular acceptance (as a file name).
+short_description: Pixel type definition.
+data:
+  - type: datatable
+    table_columns:
+      - name: pixel_type_id
+        type: uint
+        description: Pixel type ID.
+        default: 1
+        required: true
+        units: dimensionless
+      - name: photodetector_type_id
+        type: uint
+        description: Photodetector type id;
+        default: 0
+        units: dimensionless
+        required: true
+      - name: cathode_shape
+        description: "'Cathode shape, 0: circ., 1: hex(flat x), 2: sq., 3: hex(flat\
+          \ y).'"
+        type: uint
+        allowed_range:
+          min: 0
+          max: 3
+        units: dimensionless
+        required: true
+      - name: cathode_diameter
+        description: |-
+          Cathode diameter.
+          (not used when tabled light guide efficiency is provided).
+        type: double
+        units: cm
+        required: false
+      - name: pixel_shape
+        description: "'Pixel shape, 0: circ., 1: hex(flat x), 2: sq., 3: hex(flat\
+          \ y).'"
+        type: uint
+        allowed_range:
+          min: 0
+          max: 3
+        units: dimensionless
+        required: true
+      - name: pixel_diameter
+        description: Pixel diameter.
+        type: double
+        units: cm
+        required: true
+      - name: funnel_depth
+        description: |-
+          Funnel depth
+          (not used when tabled light guide efficiency is provided).
+        type: double
+        default: 0.0
+        units: cm
+        required: false
+        condition: lightguide_efficiency_vs_incident_angle==None
+      - name: pixel_transparency
+        description: Pixel transparency.
+        type: double
+        units: dimensionless
+        allowed_range:
+          min: 0.0
+          max: 1.0
+        required: false
+      - name: funnel_wall_reflectivity
+        description: |-
+          Pixel (funnel) wall reflectivity (averaged over
+          typical incident angles).
+        type: double
+        units: dimensionless
+        allowed_range:
+          min: 0.0
+          max: 1.0
+        required: false
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGeometry
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/camera_config_rotate.schema.yml
+++ b/schemas/camera_config_rotate.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for camera_config_rotate model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: camera_config_rotate
+developer_note: Part of sim_telarray camera_config_file (parameter Rotate).
+description: |-
+  Camera rotation angle, rotating the whole camera with all the pixels by
+  the given angle.
+short_description: Camera rotation angle.
+data:
+  - type: double
+    units: deg
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGeometry
+source:
+  - Initial instrument setup
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/camera_depth.schema.yml
+++ b/schemas/camera_depth.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for camera_depth model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: camera_depth
+description: |-
+  Depth of a camera body, used for shadowing.
+  If non-zero, shadowing is checked both at the height of the camera front
+  and the camera depth.
+short_description: Depth of the camera body (used to account for effects of shadowing).
+data:
+  - type: double
+    units: cm
+    allowed_range:
+      min: 0.0
+      max: 1000.0
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeShadowingParameters
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeShadowing
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/camera_filter.schema.yml
+++ b/schemas/camera_filter.schema.yml
@@ -1,0 +1,72 @@
+%YAML 1.2
+---
+title: Schema for camera_filter model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: camera_filter
+developer_note: |-
+  Note - describes both 2D and 3D tables
+  (2D in case there is no dependency on the photon incident angle
+description: |-
+  Wavelength dependence of the camera filter transmission, independent
+  of the pixel type.  The transmission may be given for the average or
+  various incident angles.  In the latter case, the transmission is
+  applied for each photon as a function of both its wavelength and its
+  incident angle.  The efficiency factors will be applied on top of the
+  global par:camera-transmission factor, and on top of any pixel-type
+  dependent efficiency (both angular and by wavelength), according to
+  the what is listed in par:camera_config_pixel_type.
+short_description: |-
+  Wavelength dependence of the camera transmission, possibly as a function
+  of incidence angle.
+data:
+  - type: datatable
+    table_columns:
+      - name: wavelength
+        description: Wavelength.
+        required: true
+        units: nm
+        type: double
+        required_range:
+          min: 300.0
+          max: 700.0
+        column_type: independent
+      - name: angle
+        description: Photon incident Angle.
+        units: deg
+        type: double
+        required: false
+        allowed_range:
+          min: 0.0
+          max: 90.0
+        column_type: independent
+      - name: camera_transmission
+        description: Camera transmission.
+        required: true
+        units: dimensionless
+        type: double
+        allowed_range:
+          min: 0.0
+          max: 1.0
+        column_type: dependent
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/camera_pixels.schema.yml
+++ b/schemas/camera_pixels.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for camera_pixels model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: camera_pixels
+description: Number of pixels in the camera.
+data:
+  - type: uint
+    required: true
+    allowed_range:
+      min: 1
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGeometry
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/camera_transmission.schema.yml
+++ b/schemas/camera_transmission.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for camera_transmission model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: camera_transmission
+description: |-
+  Global wavelength-independent transmission factor of the camera,
+  including any plexiglas window (note that transmission might be
+  included in the par:camera-filter file).
+short_description: |-
+  Global wavelength-independent transmission factor of the camera,
+  including any plexiglass window.
+data:
+  - type: double
+    default: 1.0
+    allowed_range:
+      min: 0.01
+      max: 1.0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/camera_type.schema.yml
+++ b/schemas/camera_type.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for camera_type model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: camera_type
+developer_note: |-
+  TODO - The option of flexible camera configuration is the
+  only one allowed. This parameter could be removed.
+description: |-
+  'Shape of the camera body (1: hexagonal, 2: square,
+  3: use flexible camera configuration).'
+short_description: Shape of the camera body.
+data:
+  - type: uint
+    default: 3
+    allowed_values:
+      - 3
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/default_trigger.schema.yml
+++ b/schemas/default_trigger.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for default_trigger model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: default_trigger
+description: Trigger algorithm used.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: string
+    default: Majority
+    units: dimensionless
+    allowed_values:
+      - Majority
+      - AnalogSum
+      - DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/disc_ac_coupled.schema.yml
+++ b/schemas/disc_ac_coupled.schema.yml
@@ -1,0 +1,31 @@
+%YAML 1.2
+---
+title: Schema for disc_ac_coupled model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: disc_ac_coupled
+description: Discriminators/comparator are AC coupled (if true).
+short_description: Control AC coupling of the discriminators.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: boolean
+    default: true
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/disc_bins.schema.yml
+++ b/schemas/disc_bins.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for disc_bins model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: disc_bins
+description: |-
+  Number of time bins used for the discriminator or comparator simulation.
+  This trigger simulation might cover a larger time window than the
+  FADC signals.
+short_description: Number of time bins used for the discriminator simulation.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: uint
+    units: dimensionless
+    default: 20
+    allowed_range:
+      min: 1
+      max: 200
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/disc_start.schema.yml
+++ b/schemas/disc_start.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for disc_start model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: disc_start
+description: |-
+  Number of time bins by which the discriminator or comparator simulation
+  is ahead of the FADC readout. That is mainly relevant if different time
+  windows are simulated for comparator inputs and digitized ADC values.
+short_description: |-
+  Number of time bins by which the discriminator simulation is ahead of
+  the FADC readout.
+data:
+  - type: uint
+    units: dimensionless
+    default: 0
+    allowed_range:
+      min: 1
+      max: 200
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_amplitude.schema.yml
+++ b/schemas/discriminator_amplitude.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for discriminator_amplitude model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_amplitude
+developer_note: |-
+  TODO - Units of mV are always used for CTA. Expect that this will
+  continue to be the case in future.
+  Note - sim_telarray array allows definition with arbitrary units
+  (same definition of units required for discriminator_threshold).
+description: |-
+  Signal amplitude after amplifier per mean p.e. at the input of the
+  discriminators/comparators.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: mV
+    default: 1.0
+    condition: default_trigger==AnalogSum or default_trigger==Majority
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_fall_time.schema.yml
+++ b/schemas/discriminator_fall_time.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for discriminator_fall_time model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_fall_time
+description: |-
+  Fall time of discriminator/comparator output after the logical output
+  is reset to false.
+short_description: |-
+  Fall time of the discriminator output after the logical output is
+  reset to false.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    default: 1.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 100.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_gate_length.schema.yml
+++ b/schemas/discriminator_gate_length.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for discriminator_gate_length model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_gate_length
+description: |-
+  Effective discriminator gate length. To achieve a comparator-type
+  response this gate length must match the time over threshold below.
+  Use negative values for strict discriminator type, positive values
+  for comparator or updating discriminator type.
+short_description: Effective discriminator gate length.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    default: 2.0
+    condition: default_trigger==Majority
+    allowed_range:
+      max: 100.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_hysteresis.schema.yml
+++ b/schemas/discriminator_hysteresis.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for discriminator_hysteresis model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_hysteresis
+description: |-
+  The switching off of a comparator is normally with some hysteresis to
+  avoid oscillating behavior. As a consequence, the signal has to be
+  below the threshold minus the hysteresis before it switches off.
+short_description: Value of the discriminator hysteresis.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: mV
+    default: 0.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_output_amplitude.schema.yml
+++ b/schemas/discriminator_output_amplitude.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for discriminator_output_amplitude model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_output_amplitude
+description: |-
+  The nominal output amplitude of a pixel discriminator or comparator as
+  seen at the sector (trigger group) coincidence unit.
+short_description: |-
+  The nominal output amplitude of a pixel discriminator as seen at the
+  trigger group coincidence unit.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: mV
+    default: 42.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_output_var_percent.schema.yml
+++ b/schemas/discriminator_output_var_percent.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for discriminator_output_var_percent model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_output_var_percent
+description: |-
+  Channel-to-channel variation (Gaussian r.m.s.) of the output amplitude
+  of a pixel discriminator or comparator.
+short_description: |-
+  Channel-to-channel variation (Gaussian r.m.s.) of the output amplitude
+  of a pixel discriminator.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: pct
+    default: 10.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 50.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_pulse_shape.schema.yml
+++ b/schemas/discriminator_pulse_shape.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for discriminator_pulse_shape model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_pulse_shape
+description: Pulse shape at the discriminator/comparator of an individual pixel.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: datatable
+    table_columns:
+      - name: time
+        description: Time steps.
+        required: true
+        units: ns
+        type: double
+      - name: amplitude
+        description: Pulse amplitude at the discriminator.
+        required: true
+        units: dimensionless
+        type: double
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_rise_time.schema.yml
+++ b/schemas/discriminator_rise_time.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for discriminator_rise_time model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_rise_time
+description: |-
+  Rise time of the discriminator/comparator output. After the
+  discriminator/comparator logical output is set true, the output
+  signal linearly rises from 0 to 100\% within the given time period.
+short_description: |-
+  Rise time of the discriminator output. The output signal rises linearly
+  within time frame.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    default: 1.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 100.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_sigsum_over_threshold.schema.yml
+++ b/schemas/discriminator_sigsum_over_threshold.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for discriminator_sigsum_over_threshold model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_sigsum_over_threshold
+developer_note: |-
+  Intended as mV * ns, but if unit of
+  discriminator_time_over_threshold is not mV,
+  it scales accordingly.
+description: |-
+  Integrated signal required over threshold. See also
+  discriminator_time_over_threshold above for combined effects. If
+  discriminator_time_over_threshold is not mV, it scales
+  accordingly.
+short_description: Integrated signal required over threshold.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: mV * ns
+    condition: default_trigger==Majority
+    default: 0.0
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_threshold.schema.yml
+++ b/schemas/discriminator_threshold.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for discriminator_threshold model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_threshold
+description: Discriminator/comparator threshold.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: mV
+    default: 4.0
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==Majority
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTriggerThresholdsFromRateScan
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_time_over_threshold.schema.yml
+++ b/schemas/discriminator_time_over_threshold.schema.yml
@@ -1,0 +1,44 @@
+%YAML 1.2
+---
+title: Schema for discriminator_time_over_threshold model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_time_over_threshold
+description: |-
+  Time over threshold required before logic response switches to true.
+  To achieve a comparator-type response this time must match the gate
+  length above.  Note that in addition a minimum signal integral
+  discriminator_sigsum_over_threshold may be set up. If so, both time over
+  threshold and signal integral conditions have to be met before a `true'
+  output signal starts. Normally, either of them being non-zero should be
+  sufficient.
+short_description: Time over threshold required before logic response switches to
+  true.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    default: 1.5
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 100.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_var_gate_length.schema.yml
+++ b/schemas/discriminator_var_gate_length.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for discriminator_var_gate_length model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_var_gate_length
+description: |-
+  Variation of gate length (Gaussian r.m.s.). In comparator-type
+  response, this variable is not used but only
+  discriminator_var_time_over_threshold.
+short_description: Variation of gate length (Gaussian r.m.s).
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    default: 0.1
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 100.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_var_sigsum_over_threshold.schema.yml
+++ b/schemas/discriminator_var_sigsum_over_threshold.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for discriminator_var_sigsum_over_threshold model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_var_sigsum_over_threshold
+developer_note: |-
+  Intended as mV * ns, but if unit of
+  discriminator_time_over_threshold is not mV,
+  it scales accordingly.
+description: |-
+  Gaussian r.m.s. spread of discriminator_sigsum_over_threshold
+  (Pixel-to-pixel variation).
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: mV * ns
+    default: 0.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_var_threshold.schema.yml
+++ b/schemas/discriminator_var_threshold.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for discriminator_var_threshold model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_var_threshold
+description: |-
+  Channel-to-channel variations (random Gaussian r.m.s.) of
+  discriminator/comparator threshold.
+short_description: Channel-to-channel variation of discriminator threshold.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: mV
+    default: 0.2
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/discriminator_var_time_over_threshold.schema.yml
+++ b/schemas/discriminator_var_time_over_threshold.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for discriminator_var_time_over_threshold model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: discriminator_var_time_over_threshold
+description: |-
+  Pixel-to-pixel variation of the time over threshold required before logic
+  response switches to true.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    default: 0.1
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 100.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dish_shape_length.schema.yml
+++ b/schemas/dish_shape_length.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for dish_shape_length model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dish_shape_length
+description: |-
+  Dish curvature length, best equal to focal length. For a Davies-Cotton
+  dish, this is the radius of the sphere on which the mirror tiles are
+  positioned. For a parabolic dish, this is the focal length of the
+  paraboloid on which the mirrors are placed. This parameter is only
+  needed when variations to the standard shapes are tried out, e.g.
+  intermediate shapes between parabolic and Davies-Cotton.
+short_description: Dish curvature length, best equal to focal length.
+data:
+  - type: double
+    units: cm
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 10000.0
+    condition: mirror_class==1
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_clipping.schema.yml
+++ b/schemas/dsum_clipping.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for dsum_clipping model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_clipping
+description: |-
+  The amplitude level (in ADC counts above pedestal) at which the digitized
+  signal from each pixel (after optional shaping) is clipped for its
+  contribution to the digital sum trigger.
+short_description: Amplitude level at which the digitized signal from each pixel is
+  clipped.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: int
+    default: 0
+    units: adc_counts
+    allowed_range:
+      min: 0
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_ignore_below.schema.yml
+++ b/schemas/dsum_ignore_below.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for dsum_ignore_below model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_ignore_below
+description: |-
+  FADC signals (pedestal subtracted and/or shaped) below this value,
+  i.e. in the noise, do not contribute to the digital signal sum and
+  are set to zero.  A value of zero means that no such lower threshold
+  gets applied.
+short_description: FADC signal minimum contribution to digital signal sum.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: uint
+    units: adc_counts
+    default: 0
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_offset.schema.yml
+++ b/schemas/dsum_offset.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for dsum_offset model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_offset
+description: |-
+  Offset in time where digital pulse shaping is done. Time intervals at
+  the start and end of the simulated time window that are affected by
+  shaping of missing outside signals are not used for trigger evaluation.
+short_description: Time offset applied before signal processing.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    default: 0.0
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_pedsub.schema.yml
+++ b/schemas/dsum_pedsub.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for dsum_pedsub model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_pedsub
+description: |-
+  Expected pedestal is first subtracted before any
+  shaping, scaling, clipping, etc. operations (if true).
+  Without pedestal subtraction, shaping kernels with non-zero
+  sum are not practical.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: boolean
+    default: true
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_pre_clipping.schema.yml
+++ b/schemas/dsum_pre_clipping.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for dsum_pre_clipping model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_pre_clipping
+description: |-
+  The amplitude level (in ADC counts above pedestal)
+  at which the digitized signal from each pixel (before optional shaping) is
+  clipped for its contribution to the digital sum trigger.
+  A value of zero indicates no clipping is applied.
+  Any such clipping is usually not a good idea, with FADC maximum
+  value defined by fadc_max_signal anyway.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: uint
+    units: adc_counts
+    default: 0
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_prescale.schema.yml
+++ b/schemas/dsum_prescale.schema.yml
@@ -1,0 +1,45 @@
+%YAML 1.2
+---
+title: Schema for dsum_prescale model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_prescale
+developer_note: TODO - Remove comment on DDSUM_DOUBLE?
+description: |-
+  Shaped signals are scaled by first multiplying with the
+  first value (to integer unless sim\_telarray was compiled with
+  \texttt{DDSUM_DOUBLE}) and then divided by the second value
+  (discarding the remainder).
+  No such scaling is applied if first and second value are equal.
+short_description: Scaling of shaped signals.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: uint
+    description: multiplier
+    default: 0
+    units: dimensionless
+    condition: default_trigger==DigitalSum
+  - type: uint
+    description: divider
+    default: 0
+    units: dimensionless
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_presum_max.schema.yml
+++ b/schemas/dsum_presum_max.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for dsum_presum_max model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_presum_max
+description: |-
+  After bit-shifting the pre-sum, the resulting value
+  (zero-clipped, typically) may have the given maximum
+  value to be represented in the available number of bits.
+  A value of zero implies no maximum to be applied.
+short_description: Maximum of pre-sum in available number of bits.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: uint
+    units: dimensionless
+    default: 0
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_presum_shift.schema.yml
+++ b/schemas/dsum_presum_shift.schema.yml
@@ -1,0 +1,46 @@
+%YAML 1.2
+---
+title: Schema for dsum_presum_shift model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_presum_shift
+description: |-
+  After a patch-wise pre-summation, the resulting sum may be
+  right-shifted to reduce the significant number of bits.
+  The presence of patches is indicated for
+  par:trigger_decision_circuitry
+  for the DigitalSumTrigger by e.g.\\
+  \texttt{DigitalSumTrigger * of 1[2,3] 4[5,6]} \\
+  instead of using a plain list of pixel IDs like\\
+  \texttt{DigitalSumTrigger * of 1 2 3 4 5 6}.
+short_description: |-
+  After a patch-wise pre-summation, the resulting sum may be
+  right-shifted to reduce the significant number of bits.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: uint
+    units: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+      max: 4
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_shaping.schema.yml
+++ b/schemas/dsum_shaping.schema.yml
@@ -1,0 +1,53 @@
+%YAML 1.2
+---
+title: Schema for dsum_shaping model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_shaping
+description: |-
+  Shaping (convolution) parameters for a digitized detector signal
+  (time step of ADC time slices) to the resulting signal from which a
+  digital-sum trigger decision may be derived. The values are a digital
+  signal processing kernel.  For example, a file containing
+  $\left( \begin{smallmatrix} 0 & 1\\ 1&-1 \end{smallmatrix} \right)$
+  would be a simple differencing filter,
+  $b[n] = a[n] - a[n-1]$.
+  The first column is in ADC bins behind current interval, the second
+  value is the factor applied to the corresponding ADC value.
+short_description: |-
+  Shaping (convolution) parameters for a digitized detector signal
+  to the resulting signal from which a digital-sum trigger decision may be
+  derived.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: datatable
+    table_columns:
+      - name: time
+        description: Time steps.
+        required: true
+        units: dimensionless
+        type: double
+      - name: shape
+        description: Shaping factor.
+        required: true
+        units: dimensionless
+        type: double
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_shaping_renormalize.schema.yml
+++ b/schemas/dsum_shaping_renormalize.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for dsum_shaping_renormalize model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_shaping_renormalize
+description: |-
+  The positive part of the shaping kernel is auto-normalized
+  to a sum of 1.0 (if true). If false, the shaping kernel is used as-is.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: boolean
+    default: true
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_threshold.schema.yml
+++ b/schemas/dsum_threshold.schema.yml
@@ -1,0 +1,44 @@
+%YAML 1.2
+---
+title: Schema for dsum_threshold model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_threshold
+description: |-
+  The amplitude level above pedestal sum above which a
+  digital sum leads to a telescope trigger.
+  Note that, like for discriminator/comparator and analog sum, the signal
+  must exceed (\'>\') the threshold here before we declare the telescope
+  triggered. The assigned threshold value would have to be one count lower
+  than in a camera-internal trigger implementation (like FlashCam) where
+  reaching (\’>=\’) the threshold is enough.
+short_description: Amplitude level above which a digital sum leads to a telescope
+  trigger.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: adc_counts
+    default: 0.0
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTriggerThresholdsFromRateScan
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dsum_zero_clip.schema.yml
+++ b/schemas/dsum_zero_clip.schema.yml
@@ -1,0 +1,44 @@
+%YAML 1.2
+---
+title: Schema for dsum_zero_clip model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dsum_zero_clip
+description: |-
+  With a value of 1, any negative shaped signals are clipped at zero
+  (which a non-zero dsum_ignore_below does anyway).
+  With a value of $-1$, negative signals are not clipped immediately
+  but together with patch-wise pre-summation they are clipped at zero
+  after pre-summation.
+  A value of zero means that negative shaped signals are preserved
+  for the final digital sum.
+short_description: Clipping of negative shaped signals.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: int
+    units: dimensionless
+    default: 0
+    allowed_values:
+      - 0
+      - 1
+      - -1
+    condition: default_trigger==DigitalSum
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dual_mirror_diameter.schema.yml
+++ b/schemas/dual_mirror_diameter.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for dual_mirror_diameter model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dual_mirror_diameter
+description: |-
+  The outer diameter of the primary and secondary reflectors.
+  Used only in case mirror_list is not defined (i.e., mirror_list=none).
+data:
+  - name: primary_mirror_diameter
+    type: double
+    units: cm
+    condition: mirror_list==None&&mirror_class==2
+  - name: secondary_mirror_diameter
+    type: double
+    units: cm
+    condition: mirror_list==None&&mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dual_mirror_hole_diameter.schema.yml
+++ b/schemas/dual_mirror_hole_diameter.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for dual_mirror_hole_diameter model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dual_mirror_hole_diameter
+description: |-
+  The diameter of any non-reflective part of the primary or
+  secondary mirror. For the secondary, this should not be a hole.
+  With a segments defined, it effectively clips the inner edge of
+  the segments
+data:
+  - name: primary_hole_diameter
+    description: Diameter of central hole in primary mirror.
+    type: double
+    units: cm
+    condition: mirror_class==2
+  - name: secondary_hole_diameter
+    description: Diameter of any non-reflective part of the secondary mirror.
+    type: double
+    units: cm
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dual_mirror_parameters.schema.yml
+++ b/schemas/dual_mirror_parameters.schema.yml
@@ -1,0 +1,68 @@
+%YAML 1.2
+---
+title: Schema for dual_mirror_parameters model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dual_mirror_parameters
+developer_note: |-
+  Note the application of dual_mirror_ref_radius (primary_ref_radius,
+  secondary_ref_radius) this this parameters.
+description: |-
+  Defines the position of the primary or secondary mirror along the optical
+  axis and its shape. The first parameter ($p_0$) is the offset of the
+  mirror with respect to the common reference point defined by
+  par:mirror-offset, with positive values indicating that the centre
+  of the primary (assuming it has no central hole) is above the reference
+  point. The secondary mirror looks the other way, i.e. $p_0$ will usually
+  be negative since in the coordinate frame of the secondary, it is
+  below the common reference point.  Apart from that, a parameter $p_i$
+  adds a term $p_i r^{2i}$ to the height of the mirror at
+  radial offset $r$.  A parabolic mirror will have the second parameter
+  ($p_1$) at a positive value and all further parameters at 0.
+  A concave secondary, reducing the focal length if placed between the
+  primary and its focus, will have $p_1 > 0.$.
+  A convex mirror (e.g.~for Cassegrain or Ritchey-Chr\'etien optics),
+  enlarging the focal length, will have $p_1 < 0$.
+short_description: |-
+  Parameters for a polynomial defining the position of the primary mirror
+  along the optical axis and its shape.
+data:
+  - type: datatable
+    table_columns:
+      - name: primary_mirror_parameters
+        description: |-
+          Parameters describing the primary mirror.
+          Parameters adding $p_i r^{(2i)}$ to mirror_offset
+          ($i$ is the row number starting from 0).
+        units: cm
+        type: double
+    condition: mirror_class==2
+  - type: datatable
+    table_columns:
+      - name: secondary_mirror_parameters
+        description: |-
+          Parameters describing the secondary mirror.
+          Parameters adding $p_i r^{(2i)}$ to mirror_offset
+          ($i$ is the row number starting from 0).
+        units: cm
+        type: double
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateOpticalPSF
+    - ValidateTelescopeEfficiency
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dual_mirror_ref_radius.schema.yml
+++ b/schemas/dual_mirror_ref_radius.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for dual_mirror_ref_radius model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dual_mirror_ref_radius
+description: |-
+  The length scale to which the dual_mirror_parameters apply.
+  Typical values could be 1.0 or the focal length of the
+  primary/secondary.
+short_description: The length scale to which the dual_mirror_parameters apply.
+data:
+  - name: primary_ref_radius
+    description: The length scale to which the primary_mirror_parameters apply.
+    type: double
+    units: cm
+    condition: mirror_class==2
+  - name: secondary_ref_radius
+    description: The length scale to which the secondary_mirror_parameters apply.
+    type: double
+    units: cm
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/dual_mirror_segmentation.schema.yml
+++ b/schemas/dual_mirror_segmentation.schema.yml
@@ -1,0 +1,140 @@
+%YAML 1.2
+---
+title: Schema for dual_mirror_segmentation model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: dual_mirror_segmentation
+developer_note: |-
+  Defined in a sim_telarray configuration file
+  (keywords PRIMARY_SEGMENTATION and SECONDARY_SEGMENTATION)
+  TODO - discuss usage of anyOf / allOf in this context.
+description: |-
+  Definition of segments or segment groups of the primary or secondary
+  reflector.
+  If not active (value "none") then the secondary is assumed
+  to be of one circular piece, with an optional central hole. The inner
+  and outer diameters still apply, even in case of segmentation.
+short_description: |-
+  Definition of segments or segment groups of the primary or secondary
+  reflector.
+data:
+  - name: mirror
+    description: Table below is for primary or secondary reflector.
+    type: string
+    required: true
+    allowed_values:
+      - primary
+      - secondary
+    condition: mirror_class==2
+  - name: ring
+    description: Ring-shaped segment groups.
+    type: datatable
+    required: false
+    condition: mirror_class==2
+    table_columns:
+      - name: nseg
+        description: Number of segments in this group.
+        type: uint
+        units: dimensionless
+      - name: rmin
+        description: Minimum radius of ring in x/y projection
+        type: double
+        units: cm
+      - name: rmax
+        description: Maximum radius of ring in x/y projection
+        type: double
+        units: cm
+      - name: dphi
+        description: |-
+          Angle around axis subtended by each segment.
+          For a complete ring it would be 360/nseg.
+        type: double
+        units: deg
+      - name: phi0
+        description: Angle around axis where first segment starts.
+        type: double
+        units: deg
+        default: 0.0
+      - name: gap
+        description: Gap between neighboring panels.
+        type: double
+        units: cm
+        default: 0.0
+  - name: other_segments
+    description: Squared, circular, or (Y)Hex-shaped segment groups.
+    type: datatable
+    required: false
+    condition: mirror_class==2
+    table_columns:
+      - name: segment_type
+        description: Segment shape type.
+        type: string
+        allowed_values:
+          - squared
+          - hex
+          - yhex
+          - circular
+        units: dimensionless
+      - name: segment_x
+        description: Position of segment center in x projection
+        type: double
+        units: cm
+      - name: segment_y
+        description: Position of segment center in y projection
+        type: double
+        units: cm
+      - name: segment_diameter
+        description: |-
+          Diameter of segment in projection along surface normal at
+          center.
+        type: double
+        units: cm
+      - name: segment_rotation
+        description: |-
+          Rotation angle of segment around its own axis
+          (not relevant for circular-shaped segments).
+        type: double
+        units: deg
+  - name: polygon
+    description: Polygon-shaped segment groups.
+    type: datatable
+    required: false
+    condition: mirror_class==2
+    table_columns:
+      - name: rotation
+        description: |-
+          Rotation angle of the whole segment around optical axis
+          for easier re-use of corner coordinates.
+        type: double
+        units: deg
+      - name: segment_corners
+        description: Coordinates of segment corner points.
+        type: datatable
+        units: dimensionless
+        table_columns:
+          - name: segment_corner_x
+            description: X-coordinate of segment corner point.
+            type: double
+            units: cm
+          - name: segment_corner_y
+            description: X-coordinate of segment corner point.
+            type: double
+            units: cm
+instrument:
+  class: Structure
+  type:
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateTelescopeShadowing
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/effective_focal_length.schema.yml
+++ b/schemas/effective_focal_length.schema.yml
@@ -1,0 +1,59 @@
+%YAML 1.2
+---
+title: Schema for effective_focal_length model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: effective_focal_length
+developer_note: |-
+  Not a simulation model parameter but used for the analysis only.
+  Should be discussed further if this is the right place.
+description: |-
+  Due to asymmetric image aberrations, in particular for single-reflector
+  telescope, segmented or not, the inverse image ‘plate scale’ or, more
+  precisely, the ratio of off-center distance in the focal plane
+  (projection for curved focal surface) to the tangent of the off-axis
+  angle, does not match the nominal focal plane very well. This effective
+  value here should be better suitable for shower reconstruction than the
+  nominal focal length and is supposed to be based on ray-tracing
+  simulations of point sources, at distances typical of showers and
+  imaged onto the actual focal surface at the level of the pixel entrances.
+  Non-zero values will be reported as-is in the output data and
+  may be used for the built-in reconstruction in sim_telarray. If no value is given,
+  sim_telarray may estimate a value, based on optics type and f/D ratio, for its
+  internal purpose but will not report such an estimate in the output data.
+  Due to subtle effects of image cleaning (and thus image intensity) on
+  cutting off parts of the asymmetric point-spread function, analysis
+  programs should use this value or, if not available, an estimate of it
+  only as a starting point and evaluate the actual analysis specific
+  and perhaps image intensity and NSB dependent real effective focal length
+  by itself.
+short_description: |-
+  Effective focal length.
+  Only to be used for image analysis, has no effect on the simulation.
+data:
+  - type: double
+    units: cm
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 10000.0
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetEffectiveFocalLength
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraPlateScale
+source:
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/schemas/epsg_code.schema.yml
+++ b/schemas/epsg_code.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for epsg_code model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: epsg_code
+developer_note: |-
+  Obtained from https://epsg.io/32628 and
+  https://epsg.io/32719
+description: |-
+  EPSG code to describe geodetic datums, spatial reference
+  system, and Earth ellipsoids at the site.
+short_description: Site EPSG code
+data:
+  - type: int
+    units: dimensionless
+    allowed_range:
+      min: 1024
+      max: 32767
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: gammasim-tools

--- a/schemas/fadc_ac_coupled.schema.yml
+++ b/schemas/fadc_ac_coupled.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for fadc_ac_coupled model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_ac_coupled
+description: |-
+  AC coupling of the FADCs.  If set to 1, then FADCs are AC coupled.
+  A change in night sky background rate will then only change the pedestal
+  noise but not the average pedestal.
+short_description: AC coupling of the FADCs.
+data:
+  - type: boolean
+    units: dimensionless
+    default: 1
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_amplitude.schema.yml
+++ b/schemas/fadc_amplitude.schema.yml
@@ -1,0 +1,50 @@
+%YAML 1.2
+---
+title: Schema for fadc_amplitude model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_amplitude
+description: |-
+  Peak amplitude at ADC/FADC.
+  fadc_amplitude are ADC counts maximum amplitude above pedestal
+  (per time slice) for a photo-electron with average (not most probable)
+  signal.  This is after photo detector, preamplifier, cable, and shaper
+  at the input of the ADC or FADC.
+short_description: Peak amplitude above pedestal for a photo electron with average
+  signal.
+data:
+  - type: double
+    description: FADC amplitude (for high-gain channel in case of dual-readout chain).
+    units: adc_counts
+    allowed_range:
+      min: 0.0
+  - type: double
+    description: FADC amplitude (for low-gain channel in case of dual-readout chain).
+    units: adc_counts
+    condition: num_gains==2
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+    - ValidateReadout
+    - ValidateCameraChargeResponse
+    - ValidateCameraLinearity
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_bins.schema.yml
+++ b/schemas/fadc_bins.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for fadc_bins model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_bins
+description: |-
+  Number of FADC bins to be simulated.
+  The median of all Cherenkov light photo-electrons will be near 40\% of
+  the interval length determined by fadc_bins, unless shifted by
+  photon_delay. If photon_delay is set to zero, this will be the number of
+  FADC bins read out.
+short_description: Number of FADC bins to be simulated.
+data:
+  - type: uint
+    units: dimensionless
+    allowed_range:
+      min: 1
+      max: 200
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_dev_pedestal.schema.yml
+++ b/schemas/fadc_dev_pedestal.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for fadc_dev_pedestal model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_dev_pedestal
+developer_note: |-
+  Not applicable for CTA telescopes.
+  TODO - decide if we should list parameters which are not relevant
+  for CTA (don't think we should).
+description: Deviation of (F)ADCs pedestals in a single channel.
+data:
+  - type: double
+    description: |-
+      Deviation of (F)ADCs pedestals
+      (for high-gain channel in case of dual-readout chain).
+    units: dimensionless
+    allowed_range:
+      min: 0.0
+  - type: double
+    description: |-
+      Deviation of (F)ADCs pedestals
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    units: dimensionless
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - None
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_err_pedestal.schema.yml
+++ b/schemas/fadc_err_pedestal.schema.yml
@@ -1,0 +1,50 @@
+%YAML 1.2
+---
+title: Schema for fadc_err_pedestal model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_err_pedestal
+developer_note: |-
+  TODO - check if this is relevant as this affects only the reported
+  pedestals (which are not used in the reconstruction).
+description: |-
+  Assumed error (Gaussian r.m.s.) in initial calibration of pedestal.
+  The calibration is based on a limited number of events and therefore the
+  reported pedestal value is not exactly what is used in the simulation.
+  The parameter affects only the reported pedestal
+  (reported as monitoring data), not the true pedestals used in the
+  simulation.
+short_description: |-
+  Assumed error in initial calibration of pedestal
+  (affects only the reported pedestal).
+data:
+  - type: double
+    description: |-
+      Error in pedestal calibration
+      (for high-gain channel in case of dual-readout chain).
+    units: adc_counts
+  - type: double
+    description: |-
+      Error in pedestal calibration
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    units: adc_counts
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_max_signal.schema.yml
+++ b/schemas/fadc_max_signal.schema.yml
@@ -1,0 +1,47 @@
+%YAML 1.2
+---
+title: Schema for fadc_max_signal model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_max_signal
+description: |-
+  Maximum value of digitized signal per sample.
+  For a typical 12-bit ADC this would be 4095.
+short_description: Maximum value of digitized signal per sample.
+data:
+  - type: uint
+    description: |-
+      Maximum FADC signal
+      (for high-gain channel in case of dual-readout chain).
+    units: adc_counts
+    allowed_range:
+      min: 0
+  - type: uint
+    description: |-
+      Maximum FADC signal
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    units: adc_counts
+    allowed_range:
+      min: 0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+    - ValidateCameraLinearity
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_max_sum.schema.yml
+++ b/schemas/fadc_max_sum.schema.yml
@@ -1,0 +1,45 @@
+%YAML 1.2
+---
+title: Schema for fadc_max_sum model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_max_sum
+developer_note: Not applicable for CTA telescopes.
+description: |-
+  The maximum value of a pulse sum produced by hardware pulse summation,
+  in sum mode rather than recording pulse samples.
+  Typical limitations are 15 or 16 bits, i.e. 32767 or 65535.
+short_description: |-
+  The maximum value of a pulse sum produced by hardware pulse summation,
+  in sum mode rather than recording pulse samples.
+data:
+  - type: uint
+    description: |-
+      Maximum value of a pulse sum
+      (for high-gain channel in case of dual-readout chain)
+    units: adc_counts
+    allowed_range:
+      min: 0
+  - type: uint
+    description: |-
+      Maximum value of a pulse sum
+      (for low-gain channel in case of dual-readout chain)
+    condition: num_gains==2
+    units: adc_counts
+    allowed_range:
+      min: 0
+instrument:
+  class: Camera
+  type:
+    - None
+activity:
+  setting:
+    - None
+  validation:
+    - None
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_mhz.schema.yml
+++ b/schemas/fadc_mhz.schema.yml
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+title: Schema for fadc_mhz model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_mhz
+description: FADC sampling rate.
+data:
+  - type: double
+    units: MHz
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_noise.schema.yml
+++ b/schemas/fadc_noise.schema.yml
@@ -1,0 +1,48 @@
+%YAML 1.2
+---
+title: Schema for fadc_noise model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_noise
+description: |-
+  Gaussian r.m.s. spread of white noise per time bin in digitisation
+  (for high-gain channel, if different gains are used).
+short_description: Gaussian r.m.s. spread of white noise per time bin in digitisation.
+data:
+  - type: double
+    description: |-
+      Gaussian r.m.s. spread of white noise per time bin in digitisation
+      (for high-gain channel in case of dual-readout chain)
+    units: adc_counts
+    allowed_range:
+      min: 0.0
+      max: 10.0
+  - type: double
+    description: |-
+      Gaussian r.m.s. spread of white noise per time bin in digitisation
+      (for low-gain channel in case of dual-readout chain)
+    condition: num_gains==2
+    units: adc_counts
+    allowed_range:
+      min: 0.0
+      max: 10.0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_pedestal.schema.yml
+++ b/schemas/fadc_pedestal.schema.yml
@@ -1,0 +1,45 @@
+%YAML 1.2
+---
+title: Schema for fadc_pedestal model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_pedestal
+description: (F)ADC pedestal value per time slice.
+data:
+  - type: double
+    description: |-
+      (F)ADC pedestal value per time slice
+      (for high-gain channel in case of dual-readout chain).
+    units: adc_counts
+    allowed_range:
+      min: 0.0
+  - type: double
+    description: |-
+      (F)ADC pedestal value per time slice
+      (for low-gain channel in case of dual-readout chain).
+    units: adc_counts
+    condition: num_gains==2
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+    - ValidatePedestalEvents
+    - ValidateTelescopeSimulationModel
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_pulse_shape.schema.yml
+++ b/schemas/fadc_pulse_shape.schema.yml
@@ -1,0 +1,52 @@
+%YAML 1.2
+---
+title: Schema for fadc_pulse_shape model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_pulse_shape
+description: |-
+  (F)ADC pulse shape (amplitude vs time) for low and high gain
+  readout chain.  The pulse amplitude scale is ignored and the pulses are
+  re-scaled to peak values of par:fadc-amplitude times par:fadc-sensitivity.
+short_description: (F)ADC pulse shape (amplitude vs time).
+data:
+  - type: datatable
+    table_columns:
+      - name: time
+        description: Time steps.
+        required: true
+        units: ns
+        type: double
+      - name: amplitude
+        description: Pulse amplitude high-gain channel for dual readout chains.
+        required: true
+        units: dimensionless
+        type: double
+      - name: amplitude_lg
+        description: Pulse amplitude for low-gain channel.
+        condition: num_gains==2
+        required: false
+        units: dimensionless
+        type: double
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetReadoutPulseShape
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraChargeResponse
+    - ValidateCameraTimeResponse
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_sensitivity.schema.yml
+++ b/schemas/fadc_sensitivity.schema.yml
@@ -1,0 +1,55 @@
+%YAML 1.2
+---
+title: Schema for fadc_sensitivity model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_sensitivity
+developer_note: |-
+  DISCUSS - suggest to fix this to 1. for CTA and enforce
+  that fadc_amplitude is given in the correct units.
+description: |-
+  FADC counts per mV voltage (or whatever unit is used for
+  par:fadc-amplitude).  The definition of '1.0' means that ADC
+  amplitudes have to be given directly in units of the average
+  amplitude of a single photo-electron.
+short_description: FADC counts per mV voltage.
+data:
+  - type: double
+    description: |-
+      FADC counts per mV voltage.
+      (for high-gain channel in case of dual-readout chain).
+    units: adc_counts / mV
+    allowed_range:
+      min: 0.0
+  - type: double
+    description: |-
+      FADC counts per mV voltage.
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    units: adc_counts / mV
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+    - ValidateReadout
+    - ValidateCameraChargeResponse
+    - ValidateCameraLinearity
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_sum_bins.schema.yml
+++ b/schemas/fadc_sum_bins.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for fadc_sum_bins model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_sum_bins
+description: |-
+  Number of bins summed up in ADC sum data or read out in sampled data.
+  This number corresponds to the experimental length of the readout window.
+  The start of the readout window starts fadc_sum_offset bins
+  before the calculated time of the trigger, as long as the readout window
+  fits fully in the simulated window.  With peak sensing readout, the same
+  interval is used for searching the peak signal.
+short_description: |-
+  Number of bins read out in sampled data or summed up in ADC sum data.
+  Corresponds to the experimental length of the readout window.
+data:
+  - type: uint
+    units: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_sum_offset.schema.yml
+++ b/schemas/fadc_sum_offset.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for fadc_sum_offset model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_sum_offset
+description: |-
+  Number of bins before telescope trigger where summing or reading of
+  sampled data starts (see also description of fadc_sum_bins).  With peak
+  sensing readout, the same offset is used for setting the interval for
+  the searching of the peak signal.  For negative values, the summing or
+  reading starts after the trigger.
+short_description: |-
+  Number of bins before telescope trigger where summing or reading of
+  sampled data starts.
+data:
+  - type: uint
+    units: dimensionless
+    allowed_range:
+      min: 0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_sysvar_pedestal.schema.yml
+++ b/schemas/fadc_sysvar_pedestal.schema.yml
@@ -1,0 +1,47 @@
+%YAML 1.2
+---
+title: Schema for fadc_sysvar_pedestal model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_sysvar_pedestal
+description: |-
+  Systematic common (e.g. due to temperature) variation of pedestals.
+  All reported monitoring data in the same run is offset by the same
+  (random) amount. Parameter determines the Gaussian r.m.s.
+short_description: Systematic common variations of pedestals.
+data:
+  - type: double
+    description: |-
+      Systematic common variations of pedestals.
+      (for high-gain channel in case of dual-readout chain).
+    units: adc_counts
+    allowed_range:
+      min: 0.0
+  - type: double
+    description: |-
+      Systematic common variations of pedestals.
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    units: adc_counts
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_var_pedestal.schema.yml
+++ b/schemas/fadc_var_pedestal.schema.yml
@@ -1,0 +1,46 @@
+%YAML 1.2
+---
+title: Schema for fadc_var_pedestal model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_var_pedestal
+description: |-
+  Channel-to-channel (or pixel-to-pixel) variation of the pedestal per FADC
+  time slice. Value is the r.m.s. of the randomly chosen pedestal values
+  around the FADC pedestal.
+data:
+  - type: double
+    description: |-
+      Pedestal variations
+      (for high-gain channel in case of dual-readout chain).
+    units: adc_counts
+    allowed_range:
+      min: 0.0
+  - type: double
+    description: |-
+      Pedestal variations
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    units: adc_counts
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/fadc_var_sensitivity.schema.yml
+++ b/schemas/fadc_var_sensitivity.schema.yml
@@ -1,0 +1,47 @@
+%YAML 1.2
+---
+title: Schema for fadc_var_sensitivity model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: fadc_var_sensitivity
+description: Relative variations in sensitivity (even for FADCs of the same channel).
+data:
+  - type: double
+    description: |-
+      Relative variations in sensitivity
+      (for high-gain channel in case of dual-readout chain).
+    units: dimensionless
+    allowed_range:
+      min: 0.0
+  - type: double
+    description: |-
+      Relative variations in sensitivity
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    units: dimensionless
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+    - ValidateReadout
+    - ValidateCameraChargeResponse
+    - ValidateCameraLinearity
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/flatfielding.schema.yml
+++ b/schemas/flatfielding.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for flatfielding model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: flatfielding
+developer_note: |-
+  This is of integer type in sim_telarray with allowed values 0 and 1.
+  Assigned here as type boolean, discuss if this is correct.
+description: |-
+  If enabled, the gains in pixels are adjusted to achieve the same signal
+  from the same illumination. If disabled, the gains are adjusted to
+  have equal single-p.e. amplitudes.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: boolean
+    units: dimensionless
+    default: 1
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/focal_length.schema.yml
+++ b/schemas/focal_length.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for focal_length model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: focal_length
+description: |-
+  Nominal overall focal length of the entire telescope. This defines the
+  image scale near the centre of the field of view. For segmented primary
+  focus telescopes this determines the alignment of the segments and the
+  separation from the reflector, at its centre to the camera. The
+  alignment focus is on the surface determined by the par:focus-offset
+  (see parameter description for details).  For secondary mirror
+  configurations this value is not actually used in the optics simulation
+  but only reported as a nominal value, typically close to the effective
+  focal length.
+short_description: Nominal overall focal length of the entire telescope.
+data:
+  - type: double
+    units: cm
+    default: 1500.0
+    allowed_range:
+      min: 10.0
+      max: 10000.0
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/focal_surface_parameters.schema.yml
+++ b/schemas/focal_surface_parameters.schema.yml
@@ -1,0 +1,47 @@
+%YAML 1.2
+---
+title: Schema for focal_surface_parameters model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: focal_surface_parameters
+description: |-
+  Defines the position of the focal surface along the optical axis and
+  its off-axis shape.  The par:focus-offset still applies, but with a
+  curved focal surface only in the camera centre, such that star light
+  would be focused on the camera lid surface but light from the typical
+  distance of the shower maximum would be focused on the pixel entrance.
+  Note that this offset may be impractically small with secondary mirrors
+  reducing the plate scale.  The direction of the incoming rays is not
+  transformed into the normal plane of the focal surface, thus
+  corresponding to pixels shifted w.r.t.\ to a plane.
+short_description: |-
+  Defines the position of the focal surface along the optical axis and its
+  off-axis shape.
+data:
+  - type: datatable
+    table_columns:
+      - name: focal_surface_p_i
+        description: |-
+          Parameter adding $p_i r^{(2i)}$ to focus_offset
+          ($i$ is the row number starting from 0)
+        units: cm
+        type: double
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGeometry
+    - ValidateOpticalPSF
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/focal_surface_ref_radius.schema.yml
+++ b/schemas/focal_surface_ref_radius.schema.yml
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+title: Schema for focal_surface_ref_radius model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: focal_surface_ref_radius
+description: The length scale to which the focal_surface_parameters apply.
+data:
+  - type: double
+    condition: mirror_class==2
+    units: cm
+    default: 1.0
+instrument:
+  class: Structure
+  type:
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/focus_offset.schema.yml
+++ b/schemas/focus_offset.schema.yml
@@ -1,0 +1,64 @@
+%YAML 1.2
+---
+title: Schema for focus_offset model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: focus_offset
+description: |-
+  Distance of the starlight focus from the camera pixels (light guides)
+  entry. In telescopes without dynamic focusing capability (either
+  through mirror alignment and camera positioning) this is best set
+  such that starlight gets focused onto the camera lid while showers
+  are focused onto the pixel entry.
+  Zenith angle dependence of the focus offset can be applied and includes
+  the constant value $\Delta_0$ and terms depending on cosine and sine
+  of the zenith angle. The total focus offset is
+  $\Delta = \Delta_0 + \Delta_c + \Delta_s$.
+  Set to zero for all 2M telescope types, as it is already included in
+  the first of the par:focal-surface-parameters values, assuming the
+  design value of that is for a light source at a typical shower maximum
+  distance.
+short_description: |-
+  Distance of the starlight focus from the camera pixels (light guides)
+  entry.
+data:
+  - type: double
+    name: focus_offset
+    description: Constant focus offset $\Delta_0$.
+    units: cm
+    default: 2.8
+  - type: double
+    description: Zenith angle $\Delta_0$ at which minimum is reached.
+    units: deg
+    default: 28.0
+  - type: double
+    description: |-
+      Scaling term $k_c$ in
+      $\Delta_c = (\cos(\theta)-\cos(\theta_0)) / k_c$.
+    units: dimensionless
+    default: 0.0
+  - type: double
+    description: |-
+      Scaling term $k_s$ in
+      $\Delta_s = (\sin(\theta)-\sin(\theta_0)) / k_s$.
+    units: dimensionless
+    default: 0.0
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateOpticalPSF
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/gain_variation.schema.yml
+++ b/schemas/gain_variation.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for gain_variation model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: gain_variation
+short_description: |-
+  Fractional gain variation between different photo detectors after
+  adjusting the voltage to have approximately the same gain in all channels.
+description: |-
+  Fractional gain variation between different photo detectors after
+  adjusting the voltage to have approximately the same gain in all channels.
+  The parameter sets the Gaussian r.m.s. spread of random fluctuations, used
+  as \texttt{amplitude *= RandGaus(1., gain_variation)}.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: dimensionless
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraChargeResponse
+    - ValidateCameraGainsAndEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/hg_lg_variation.schema.yml
+++ b/schemas/hg_lg_variation.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for hg_lg_variation model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: hg_lg_variation
+description: |-
+  Relative pixel-to-pixel variation of the ratio of high-gain to
+  low-gain amplitudes.
+data:
+  - type: double
+    required: false
+    condition: num_gains==2
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 0.25
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - NectarCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/lightguide_efficiency_vs_incident_angle.schema.yml
+++ b/schemas/lightguide_efficiency_vs_incident_angle.schema.yml
@@ -1,0 +1,50 @@
+%YAML 1.2
+---
+title: Schema for lightguide_efficiency_vs_incident_angle model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: lightguide_efficiency_vs_incident_angle
+developer_note: Part of sim_telarray camera_config_file (parameter PixType).
+description: |-
+  Lightguide efficiency as a function of incidence angle.
+  The wavelength dependence is averaged over, weighting by the
+  Cherenkov spectrum on the ground.
+short_description: Lightguide efficiency as a function of incidence angle.
+data:
+  - type: datatable
+    table_columns:
+      - name: angle
+        description: Photon incident angle.
+        required: true
+        units: deg
+        type: double
+      - name: lightguide_efficiency
+        description: Wavelength averaged lightguide efficiency
+        required: true
+        units: dimensionless
+        type: double
+        allowed_range:
+          min: 0.0
+          max: 1.0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetLightGuideEfficiency
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/lightguide_efficiency_vs_wavelength.schema.yml
+++ b/schemas/lightguide_efficiency_vs_wavelength.schema.yml
@@ -1,0 +1,76 @@
+%YAML 1.2
+---
+title: Schema for lightguide_efficiency_vs_wavelength model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: lightguide_efficiency_vs_wavelength
+developer_note: |-
+  The extra funnel efficiency table is interpreted such that
+  efficiency factors are not double-counted on top of that in
+  the angle-dependence table (normalized to yield no extra
+  correction for 400 nm wavelength at the expected average
+  incidence angle).
+  This is not interchangeable with the window filter transmission.
+  Part of sim_telarray camera_config_file (parameter PixType).
+description: Lightguide efficiency for on-axis photons vs wavelength.
+data:
+  - type: datatable
+    table_columns:
+      - name: wavelength
+        description: Wavelength.
+        required: true
+        units: nm
+        type: double
+        required_range:
+          min: 300.0
+          max: 700.0
+      - name: lightguide_efficiency
+        description: Average lightguide efficiency within angle range.
+        required: true
+        units: dimensionless
+        type: double
+        allowed_range:
+          min: 0.0
+          max: 1.0
+  - name: averaging_angle_min
+    description: |-
+      Minimum incident angle used for the calculation of
+      the lightguide efficiency.
+    type: double
+    units: deg
+    required: true
+    allowed_range:
+      min: 0.0
+      max: 90.0
+  - name: averaging_angle_max
+    description: |-
+      Maximum incident angle used for the calculation of
+      the lightguide efficiency.
+    type: double
+    units: deg
+    required: true
+    allowed_range:
+      min: 0.0
+      max: 90.0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetLightGuideEfficiency
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/magnetic_field.schema.yml
+++ b/schemas/magnetic_field.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for magnetic_field model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: magnetic_field
+description: Geomagnetic field at given site.
+data:
+  - type: double
+    units: uT
+    description: horizontal geomagnetic field component (H).
+  - type: double
+    units: uT
+    description: vertical geomagnetic field component (Z).
+  - type: double
+    units: deg
+    description: |-
+      rotation angle of x-axis relative to magnetic north
+      (corresponds to CORSIKA ARRANG parameter)
+    allowed_range:
+      min: -180.0
+      max: 180.0
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetGeomagneticField
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateAtmosphericModel
+    - ValidateTelescopeSimulationModel
+source:
+  - External
+simulation_software:
+  - name: corsika

--- a/schemas/mirror_align_random_distance.schema.yml
+++ b/schemas/mirror_align_random_distance.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for mirror_align_random_distance model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: mirror_align_random_distance
+description: |-
+  Gaussian r.m.s. spread of random fluctuations in the aligned mirror
+  distance from the focus.
+data:
+  - type: double
+    units: cm
+    default: 2.0
+    condition: mirror_class==1
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+activity:
+  setting:
+    - SetMirrorPanelAlignment
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateOpticalPSF
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/schemas/mirror_align_random_horizontal.schema.yml
+++ b/schemas/mirror_align_random_horizontal.schema.yml
@@ -1,0 +1,62 @@
+%YAML 1.2
+---
+title: Schema for mirror_align_random_horizontal model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: mirror_align_random_horizontal
+description: |-
+  Fluctuations of the mirror alignment angle with respect to nominal
+  alignment in the horizontal component (in azimuth or y direction in
+  dish coordinates). The three terms are added up as independent
+  (i.e., by squares; therefore he square of the horizontal mirror
+  alignment error is $\sigma^2 = \sigma_0^2 + \sigma_c^2 + \sigma_s^2$).
+  The values here are usually derived from fits to the measured point
+  spread functions, with the single mirror point-spread function adapted
+  beforehand. Note that, since this affects the angles of the mirrors,
+  the impact on the combined spot size is twice as large.
+short_description: |-
+  Gaussian r.m.s. spread of random fluctuations of the mirror alignment
+  angle with respect to nominal alignment in the horizontal component.
+data:
+  - type: double
+    description: Constant value $\sigma_0$.
+    units: deg
+    default: 0.0035
+  - type: double
+    description: Zenith angle $\theta_0$ at which minimum is reached.
+    units: deg
+    default: 28.0
+  - type: double
+    description: |-
+      Scaling term $k_c$ in
+      $\sigma_c = (\cos(\theta)-\cos(\theta_0)) / k_c$.
+    units: dimensionless
+    default: 0.0023
+  - type: double
+    description: |-
+      Scaling term $k_s$ in
+      $\sigma_s = (\sin(\theta)-\sin(\theta_0)) / k_s$.
+    units: dimensionless
+    default: 0.0023
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetMirrorPanelAlignment
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateOpticalPSF
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/schemas/mirror_align_random_vertical.schema.yml
+++ b/schemas/mirror_align_random_vertical.schema.yml
@@ -1,0 +1,62 @@
+%YAML 1.2
+---
+title: Schema for mirror_align_random_vertical model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: mirror_align_random_vertical
+description: |-
+  Fluctuations of the mirror alignment angle with respect to nominal
+  alignment in the vertical component (in altitude or $x$ direction in
+  dish coordinates). The three terms are added up as independent
+  (i.e., by squares; therefore he square of the vertical mirror
+  alignment error is $\sigma^2 = \sigma_0^2 + \sigma_c^2 + \sigma_s^2$).
+  The values here are usually derived from fits to the measured point
+  spread functions, with the single mirror point-spread function adapted
+  beforehand. Note that, since this affects the angles of the mirrors,
+  the impact on the combined spot size is twice as large.
+short_description: |-
+  Gaussian r.m.s. spread of random fluctuations of the mirror alignment
+  angle with respect to nominal alignment in the vertical component.
+data:
+  - type: double
+    description: Constant value $\sigma_0$.
+    units: deg
+    default: 0.0034
+  - type: double
+    description: Zenith angle $\theta_0$ at which minimum is reached.
+    units: deg
+    default: 28.0
+  - type: double
+    description: |-
+      Scaling term $k_c$ in
+      $\sigma_c = (\cos(\theta)-\cos(\theta_0)) / k_c$.
+    units: dimensionless
+    default: 0.01
+  - type: double
+    description: |-
+      Scaling term $k_s$ in
+      $\sigma_s = (\sin(\theta)-\sin(\theta_0)) / k_s$.
+    units: dimensionless
+    default: 0.0
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetMirrorPanelAlignment
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateOpticalPSF
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/schemas/mirror_class.schema.yml
+++ b/schemas/mirror_class.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for mirror_class model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: mirror_class
+description: |-
+  Parameter to control the type of mirror used.
+  Includes segmented primary mirror optics with spherical mirror tiles (0),
+  parabolic primary made of a single piece (1), and a a secondary mirror
+  optics (2), with primary and secondary each made of a single piece.
+  Class 3 represents a simple Fresnel lens implementation.
+short_description: Parameter to control the type of mirror used (DC, parabolic or
+  SC).
+data:
+  - type: uint
+    units: dimensionless
+    allowed_range:
+      min: 0
+      max: 3
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/mirror_focal_length.schema.yml
+++ b/schemas/mirror_focal_length.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for mirror_focal_length model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: mirror_focal_length
+description: |-
+  Standard focal length of mirror tiles. This parameter is only used if
+  the focal lengths of the mirror tiles in the par:mirror_list
+  are zero. For a parabolic dish any non-zero value will then force
+  all mirror tiles to have the same focal lengths (which should then match
+  the average distance of the parabolic dish from the focus, not exactly
+  the overall focal length).
+short_description: Standard focal length of mirror tiles.
+data:
+  - type: double
+    units: cm
+    default: 0.0
+    allowed_range:
+      min: 10.0
+      max: 10000.0
+    condition: mirror_class==1
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateMirrorPanelParameters
+    - ValidateOpticalPSF
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/mirror_list.schema.yml
+++ b/schemas/mirror_list.schema.yml
@@ -1,0 +1,80 @@
+%YAML 1.2
+---
+title: Schema for mirror_list model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: mirror_list
+description: List of mirror positions, diameters, focal lengths, and shape codes.
+data:
+  - type: datatable
+    table_columns:
+      - name: mirror_x
+        description: Mirror x position (North/Down).
+        units: cm
+        required: true
+        type: double
+      - name: mirror_y
+        description: Mirror y position (West/Right from camera).
+        units: cm
+        required: true
+        type: double
+      - name: mirror_diameter
+        description: Mirror flat-to-flat diameter
+        units: cm
+        required: true
+        type: double
+      - name: focal_length
+        description: |-
+          Mirror focal length.
+          Note if positive, no par:random_focal_length based values added.
+        units: cm
+        required: true
+        type: double
+      - name: shape_type
+        description: |-
+          Mirror shape type (0=circular,
+          1=hex. with flat side parallel to y,
+          2=square, 3=other hexagonal).
+        units: dimensionless
+        type: uint
+        allowed_values:
+          - 0
+          - 1
+          - 2
+          - 3
+        default: 0
+        required: false
+      - name: mirror_z
+        description: Mirror height above dish back plane.
+        units: cm
+        required: false
+        type: double
+      - name: mirror_id
+        description: Mirror identifier.
+        type: uint
+        units: dimensionless
+        required: false
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateMirrorPanelParameters
+    - ValidateOpticalPSF
+    - ValidateTelescopeStructure
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeShadowing
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/mirror_offset.schema.yml
+++ b/schemas/mirror_offset.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for mirror_offset model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: mirror_offset
+description: |-
+  Offset of mirror back plane from fixed point of telescope mount
+  (if axes intersect) or from the altitude rotation axis, along
+  the direction of the optical axis.  Positive if fixed point
+  (or altitude axis) is between the mirror back plane and the focus or,
+  in other words, the center of the primary mirror is behind/below
+  the altitude rotation axis.
+short_description: |-
+  Offset of mirror back plane from fixed point of telescope mount or
+  from the altitude rotation axis, along the direction of the optical axis.
+data:
+  - type: double
+    units: cm
+    default: 130.0
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/mirror_reflection_random_angle.schema.yml
+++ b/schemas/mirror_reflection_random_angle.schema.yml
@@ -1,0 +1,59 @@
+%YAML 1.2
+---
+title: Schema for mirror_reflection_random_angle model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: mirror_reflection_random_angle
+description: |-
+  Gaussian random fluctuations of reflection angles, due to
+  small-scale surface deviations, with one or two components.
+  For two components, the random reflection angle is applied
+  separately to each projection, in the coordinate system of the mirror
+  surface, with the same r.m.s. in both projections.
+short_description: |-
+  Gaussian r.m.s. spread of random fluctuations of microscopic reflection
+  angles due to small-scale surface deviations.
+data:
+  - type: double
+    description: Projected Gaussian r.m.s. of the first component.
+    units: deg
+    default: 0.0066
+    allowed_range:
+      min: 0.0
+      max: 2.0
+  - type: double
+    description: Fractional amplitude of second component.
+    units: dimensionless
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 1.0
+  - type: double
+    description: Projected Gaussian r.m.s. of the second component.
+    units: deg
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 2.0
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetMirrorPanelRandomReflection
+    - SetParameterFromExternal
+  validation:
+    - ValidateMirrorPanelParameters
+    - ValidateOpticalPSF
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/schemas/mirror_reflectivity.schema.yml
+++ b/schemas/mirror_reflectivity.schema.yml
@@ -1,0 +1,110 @@
+%YAML 1.2
+---
+title: Schema for mirror_reflectivity model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: mirror_reflectivity
+developer_note: |-
+  Note - describes both 2D and 3D tables
+  (2D in case there is no dependency on the photon incident angle)
+description: |-
+  Mirror reflectivity measured directly on the facet as function of
+  wavelength. For dual mirror telescopes without explicit reflectivity
+  table given for the secondary, this reflectivity given here is
+  applied twice.
+data:
+  - name: mirror_reflectivity
+    description: |-
+      Reflectivity table
+      (for primary mirror in case of dual-mirror telescopes).
+    required: true
+    type: datatable
+    table_columns:
+      - name: wavelength
+        description: Wavelength.
+        units: nm
+        type: double
+        required: true
+        column_type: independent
+      - name: incident_angle
+        description: Photon incident angle.
+        type: double
+        units: deg
+        required: false
+        column_type: independent
+      - name: reflectivity
+        description: Reflectivity.
+        type: double
+        units: dimensionless
+        allowed_range:
+          min: 0.0
+          max: 1.0
+        required: true
+        column_type: dependent
+      - name: reflectivity_1sigma
+        description: Uncertainty (1 sigma) on reflectivity.
+        type: double
+        units: dimensionless
+        allowed_range:
+          min: 0.0
+          max: 1.0
+        required: false
+        column_type: dependent
+  - name: mirror_secondary_reflectivity
+    description: Reflectivity table for secondary mirror.
+    required: false
+    condition: mirror_class==2
+    type: datatable
+    table_columns:
+      - name: wavelength
+        description: Wavelength.
+        units: nm
+        type: double
+        required: true
+        column_type: independent
+      - name: incident_angle
+        description: Photon incident angle.
+        type: double
+        units: deg
+        required: false
+        column_type: independent
+      - name: reflectivity
+        description: Reflectivity (secondary mirror).
+        units: dimensionless
+        allowed_range:
+          min: 0.0
+          max: 1.0
+        type: double
+        required: true
+        column_type: dependent
+      - name: reflectivity_1sigma
+        description: Uncertainty (1 sigma) on reflectivity (secondary mirror).
+        type: double
+        units: dimensionless
+        allowed_range:
+          min: 0.0
+          max: 1.0
+        required: false
+        column_type: dependent
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeEfficiency
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTriggerPerformance
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/multiplicity_offset.schema.yml
+++ b/schemas/multiplicity_offset.schema.yml
@@ -1,0 +1,45 @@
+%YAML 1.2
+---
+title: Schema for multiplicity_offset model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: multiplicity_offset
+description: |-
+  This number tells where the actual threshold of the telescope trigger
+  is adjusted relative to the nominal number of required pixels.
+  A value of -0.5 means that with par:trigger-pixels of 4, the sum of
+  pixel discriminator/comparator outputs must exceed 3.5 times the
+  average output amplitude for the given minimum time and by the
+  given minimum signal integral in order to accept any `sector'
+  trigger (and therefore a telescope trigger) with the majority
+  trigger logic.
+short_description: |-
+  Actual threshold of the telescope trigger, adjusted relative to the
+  number of required pixels.
+data:
+  - type: double
+    units: dimensionless
+    default: -0.5
+    allowed_range:
+      min: -0.5
+      max: 0.5
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/night_sky_background_spectrum.schema.yml
+++ b/schemas/night_sky_background_spectrum.schema.yml
@@ -1,0 +1,50 @@
+%YAML 1.2
+---
+title: Schema for night_sky_background_spectrum model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: night_sky_background_spectrum
+developer_note: |
+  TODO - check that wavelength range is sufficient
+  TODO - add possible zenith / azimuth dependence
+  (see Granada talk by C. Righi)
+description: Intensity of night-sky background light as function of wavelength.
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+data:
+  - type: datatable
+    table_columns:
+      - name: wavelength
+        description: Wavelength
+        required: true
+        units: nm
+        type: double
+        required_range:
+          min: 300.0
+          max: 700.0
+        input_processing:
+          - remove_duplicates
+          - sort
+      - name: intensity
+        description: Intensity of the night-sky background
+        required: true
+        units: photons / arcsec**2 m**2 s** micron
+        type: double
+        required_range:
+          min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/nightsky_background.schema.yml
+++ b/schemas/nightsky_background.schema.yml
@@ -1,0 +1,64 @@
+%YAML 1.2
+---
+title: Schema for nightsky_background model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: nightsky_background
+description: |-
+  'Number of photo-electrons per nanosecond per pixel due to night-sky
+  background. Note that the number here takes into account all
+  photo-electrons, including those not properly amplified or lost at the
+  first dynode.  A range of pixels can be given with
+  nightsky_background = (0-1236): 0.2, (1237-1854): 0.15.
+  Alternatively, all pixels can be set with nightsky_background = all: 0.2.'
+short_description: |-
+  Number of photo-electrons per nanosecond per pixel due to nightsky
+  background.
+data:
+  - type: double
+    units: GHz
+  - type: datatable
+    table_columns:
+      - name: pixel_id
+        type: uint
+        description: Pixel number (starting at 0)
+        required: true
+        units: dimensionless
+      - name: nightsky_background
+        description: Night-sky background rate per pixel.
+        type: double
+        units: GHz
+        default: 0.1
+        required: true
+        allowed_range:
+          min: 0.0
+      - name: pixel_range
+        description: |-
+          Pixel range for this row (e.g., use 'all'
+          if the same value is used for all pixels).
+        type: string
+        required: false
+        units: dimensionless
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetNightSkyBackgroundRate
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+    - ValidateTriggerPerformance
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/nsb_gain_drop_scale.schema.yml
+++ b/schemas/nsb_gain_drop_scale.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for nsb_gain_drop_scale model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: nsb_gain_drop_scale
+description: |-
+  This parameter, if non-zero, indicates the pixel p.e. rate at which the
+  gain drops to half the nominal value due to bias resistance and
+  cell capacitance (applicable as such for SiPM cameras). \\
+  \textbf{Example:} 1./(2.4 [kOhm] $\times$ 85 [fF])/1e9 [ns] = 4.90 [GHz].
+short_description: |-
+  Pixel p.e. rate at which the gain drops to half the nominal value due to
+  bias resistance and cell capacitance (SiPM cameras).
+data:
+  - type: double
+    units: GHz
+    default: 0.0
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGainsAndEfficiency
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/nsb_offaxis.schema.yml
+++ b/schemas/nsb_offaxis.schema.yml
@@ -1,0 +1,69 @@
+%YAML 1.2
+---
+title: Schema for nsb_offaxis model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: nsb_offaxis
+description: |-
+  Fall-off of NSB with off-axis angle due to change of effective optical
+  area across the field of view (partly covered by
+  par:telescope-transmission).  The first parameter is the function
+  number. Function zero is a constant (all following parameters ignored),
+  function one is $f = 1/(1 + p_1 * (r/p_2)^{p_3})$ if $p_4=0$ or missing
+  and $f = 1/(1 + p_1 * (r/p_2)^{p_3})^{p_4}$ if $p_4\ne0$ where
+  $r$ is the ($x$/$y$ projected) pixel off-axis radius and $p_1$ to
+  $p_4$ are the second to fifth parameter, with $p_2$ understood as a
+  camera reference radius for the purpose of this function.
+short_description: |-
+  Fall-off of NSB with off-axis angle due to off-axis angle-dependent
+  effective optical area.
+data:
+  - name: nsb_offaxis_function
+    required: false
+    type: uint
+    description: |
+      Function identifier.
+    default: 0
+    allowed_range:
+      min: 0
+      max: 1
+    units: dimensionless
+  - name: reference_radius_p2
+    description: |
+      Camera reference radius $p_2$.
+    required: false
+    type: double
+    default: 0.0
+    units: cm
+  - name: nsb_offaxis_p3
+    description: |
+      Effective optical area factor $p_3$.
+    required: false
+    type: double
+    default: 0.0
+    units: dimensionless
+  - name: nsb_offaxis_p4
+    description: |
+      Effective optical area factor $p_4$.
+    required: false
+    type: double
+    default: 0.0
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetNightSkyBackgroundRate
+    - SetParameterFromExternal
+  validation:
+    - ValidatePedestalEvents
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/nsb_scaling_factor.schema.yml
+++ b/schemas/nsb_scaling_factor.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for nsb_scaling_factor model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: nsb_scaling_factor
+description: |-
+  Common scaling of the NSB in all pixels of all telescopes against
+  reference setting.
+short_description: Global NSB scaling factor.
+data:
+  - type: double
+    units: dimensionless
+    default: 1.0
+    allowed_range:
+      min: 0.0
+      max: 10000.0
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/nsb_sky_map.schema.yml
+++ b/schemas/nsb_sky_map.schema.yml
@@ -1,0 +1,52 @@
+%YAML 1.2
+---
+title: Schema for nsb_sky_map model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: nsb_sky_map
+description: |-
+  An optional sky map (Az/Alt) of NSB enhancement factors, counted on top
+  of the configured pixel NSB p.e. rates and other scaling factors
+  mentioned in this section, but not any starlight which might get
+  added additionally. Recommend is to provide a regular grid in
+  azimuth and altitude. This map will be evaluated for each pixel
+  center pointed back into the sky, using the effective focal length
+  (no explicit ray-tracing), thus is only suitable for changes in
+  sky brightness exceeding the pixel sizes.
+short_description: Sky map (Az/Alt) of NSB enhancement factors.
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+data:
+  - type: datatable
+    table_columns:
+      - name: azimuth
+        description: Azimuth angle (grid center)
+        type: double
+        required: true
+        units: deg
+      - name: altitude
+        description: Altitude angle (grid center)
+        type: double
+        required: true
+        units: deg
+      - name: nsb_enhancement_factor
+        description: NSB enhancement factor
+        type: double
+        required: true
+        units: dimensionless
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/num_gains.schema.yml
+++ b/schemas/num_gains.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for num_gains model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: num_gains
+description: Number of different gains the input signal gets digitized.
+data:
+  - type: int
+    units: dimensionless
+    default: 1
+    allowed_range:
+      min: 1
+      max: 2
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/only_triggered_telescopes.schema.yml
+++ b/schemas/only_triggered_telescopes.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for only_triggered_telescopes model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: only_triggered_telescopes
+description: |-
+  Triggered telescopes are read out only (if true), otherwise
+  non-triggered telescopes are also read out.
+short_description: Switch to read out non-triggered telescopes.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: boolean
+    default: true
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/parabolic_dish.schema.yml
+++ b/schemas/parabolic_dish.schema.yml
@@ -1,0 +1,31 @@
+%YAML 1.2
+---
+title: Schema for parabolic_dish model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: parabolic_dish
+description: |-
+  Parabolic dish.
+  Mirror tiles still have spherical shape (similar to the Davies-Cotton
+  optics), but their focal lengths are adapted to the distance from the
+  focus (since the geometric mean of minimum and maximum radius of
+  curvature of the paraboloid is very close to that distance).
+short_description: Parabolic dish shape is used.
+data:
+  - type: boolean
+    default: false
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/peak_sensing.schema.yml
+++ b/schemas/peak_sensing.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for peak_sensing model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: peak_sensing
+description: |-
+  Report sample with the largest signal in the range otherwise
+  used for ADC sums instead of sampling the pulses and optionally
+  integrating signals over a given number of samples.
+  The output is reported to be an ADC sum over
+  one sample; also pedestals are for one sample only.
+  This option is incompatible with sample-mode output.
+short_description: Use peak sensing instead of sampling of the pulse.
+data:
+  - type: boolean
+    units: dimensionless
+    default: 0
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/photon_delay.schema.yml
+++ b/schemas/photon_delay.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for photon_delay model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: photon_delay
+developer_note: |-
+  Type corrected with respect to the sim_telarray manual
+  (double, not int)
+description: |-
+  Additional delay added to the arrival times
+  of all photons at the photo sensors.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    default: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetPhotonDelay
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/pixel_cells.schema.yml
+++ b/schemas/pixel_cells.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for pixel_cells model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: pixel_cells
+description: |-
+  Modeling of pixel saturation. Value corresponds to the
+  limited number of cells in a pixel (of SiPM type) which each can only
+  fire once during the typical arrival time spread of Cherenkov photons.
+  The presence of a non-zero value does not imply any microscopic model
+  of the pixel structure.
+instrument:
+  class: Camera
+  type:
+    - SSTCam
+    - SCTCam
+data:
+  - type: int
+    units: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraChargeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/pixels_parallel.schema.yml
+++ b/schemas/pixels_parallel.schema.yml
@@ -1,0 +1,54 @@
+%YAML 1.2
+---
+title: Schema for pixels_parallel model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: pixels_parallel
+description: |-
+  Parameter controlling the orientation of the pixels, setting it to be
+  aligned with the optical axis or the focal surface normal.
+  A value of 0 indicates that the pixel is oriented such that the surface
+  is aligned with the focal surface (pixel axis parallel to focal surface
+  normal).
+  A value of 1 indicates, that pixels are only shifted parallel to the
+  optical axis. Pixel surfaces remain perpendicular to the optical axis.
+  A value of 2 places all pixels belonging to the same module
+  (as configured in the ``Pixels'' lines in the par:camera-config-file)
+  on a common plane, with its orientation along the normal to the focal
+  surface in the module center (c.o.g. of pixels) and with zero mean
+  displacements of pixels along the $z$ axis.
+  A value of 3 (=2+1) has all pixels in a common plane per module and
+  all of the modules (and thus all of the pixels) looking parallel to
+  the optical axis. The ‘height’ (in z) of the module is again the
+  average of where individually placed pixels would be (zero mean
+  displacement in module).
+  An extension to the camera definition file even allows for pixels to be
+  configured individually and not exactly following the focal surface
+  (in both height and orientation).
+short_description: |-
+  Parameter controlling the orientation of the pixels, setting it to be
+  aligned with the optical axis or the focal surface normal.
+data:
+  - type: uint
+    default: 1
+    allowed_range:
+      min: 0
+      max: 3
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGeometry
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/pixeltrg_time_step.schema.yml
+++ b/schemas/pixeltrg_time_step.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for pixeltrg_time_step model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: pixeltrg_time_step
+description: |-
+  If non-zero, the time between the telescope trigger and the time
+  when the pixel discriminator/comparator fired is recorded under
+  the telescope event in the given time steps (negative for
+  pixels fired before the telescope trigger; possible delays involved
+  in a real instrument are not accounted for).
+short_description: Time difference between telescope and pixel trigger recording.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    default: 0.0
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/pm_average_gain.schema.yml
+++ b/schemas/pm_average_gain.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for pm_average_gain model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: pm_average_gain
+description: |-
+  Photo detector average gain. Used to determine the DC currents
+  from night-sky background (NSB) pixel rates.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+data:
+  - type: double
+    allowed_range:
+      min: 10000.0
+      max: 30000000.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateNightSkyBackgroundMeasurement
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/pm_collection_efficiency.schema.yml
+++ b/schemas/pm_collection_efficiency.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for pm_collection_efficiency model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: pm_collection_efficiency
+developer_note: Always set to 1. for CTA cameras.
+short_description: |-
+  Photoelectron collection efficiency at the first stage of the photo
+  detector.
+description: |-
+  Photoelectron collection efficiency at the first stage of the photo
+  detector. The default value is 1.0 since in most cases the non-amplified
+  photo-electrons are included in the amplitude distribution of the
+  single-p.e. spectrum.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+data:
+  - type: double
+    units: dimensionless
+    allowed_range:
+      min: 0.01
+      max: 1.0
+    default: 1.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/pm_gain_index.schema.yml
+++ b/schemas/pm_gain_index.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for pm_gain_index model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: pm_gain_index
+description: |-
+  PMT gain g and voltage U are assumed to be related by
+  the PMT gain index p through $g \propto U^{p}$.
+  Used only for PMT timing.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+data:
+  - type: double
+    units: dimensionless
+    allowed_range:
+      min: 0.0
+      max: 15.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/pm_photoelectron_spectrum.schema.yml
+++ b/schemas/pm_photoelectron_spectrum.schema.yml
@@ -1,0 +1,60 @@
+%YAML 1.2
+---
+title: Schema for pm_photoelectron_spectrum model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: pm_photoelectron_spectrum
+description: |-
+  Single photoelectron (p.e.) response distribution
+  (takes into account afterpulsing and the photoelectron collection
+  efficiency for PMT cameras).
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: datatable
+    table_columns:
+      - name: amplitude
+        description: |-
+          Single photo-electron amplitude in p.e. units.
+          Scaled such that the centre of gravity of the
+          amplitude distribution is 1.0.
+        required: true
+        units: dimensionless
+        type: double
+        required_range:
+          min: 0.0
+          max: 10000000000.0
+        input_processing:
+          - remove_duplicates
+          - sort
+      - name: response
+        description: Single-p.e. response defined as probability times an arbitrary
+          scaling factor.
+        required: true
+        units: dimensionless
+        type: double
+        allowed_range:
+          min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetSinglePhotoElectronResponse
+  validation:
+    - ValidateParameterByExpert
+    - ValidateSinglePhotoElectronResponse
+    - ValidateCameraChargeResponse
+    - ValidateCameraLinearity
+    - ValidateCameraGainsAndEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/pm_transit_time.schema.yml
+++ b/schemas/pm_transit_time.schema.yml
@@ -1,0 +1,61 @@
+%YAML 1.2
+---
+title: Schema for pm_transit_time model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: pm_transit_time
+description: Total transit time of the photodetector at the average voltage.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+data:
+  - name: pm_transit_time_at_average_voltage
+    type: double
+    description: Total transit time of the PMT at the average voltage.
+    units: ns
+    allowed_range:
+      min: 0.0
+  - name: pm_transit_time_to_first_dynode
+    type: double
+    description: |-
+      Fixed transit time between cathode and first dynode, in case of
+      the first dynode being stabilized. Use zero for a passive divider.
+    units: ns
+    default: 0.0
+    allowed_range:
+      min: 0.0
+  - name: fixed_voltage_first_dynode
+    type: double
+    description: |-
+      The fixed voltage (or fraction of total nominal voltage) applied to
+      a stabilized first dynode. Use zero for a passive divider.
+    units: V
+    default: 0.0
+    allowed_range:
+      min: 0.0
+    developer_note: "This parameter can describe in sim_telarray the fraction of total\n\
+      nominal voltage in case total nominal voltage is set to zero."
+  - name: total_nominal_voltage
+    type: double
+    default: 0.0
+    description: Total nominal voltage.
+    units: V
+    allowed_range:
+      min: 0.0
+    developer_note: "If zero (or one), the third value of the fixed voltage is assumed\
+      \ to\nrepresent the fraction of the total nominal voltage in sim_telarray."
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/pm_voltage_variation.schema.yml
+++ b/schemas/pm_voltage_variation.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for pm_voltage_variation model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: pm_voltage_variation
+short_description: |-
+  Fractional high voltage variation, used to adjust the transit time
+  variations ($\propto 1/\sqrt(V)$).
+description: |-
+  Fractional high voltage variation, used to adjust the transit time
+  variations ($\propto 1/\sqrt(V)$).  The parameter sets the Gaussian
+  r.m.s. spread of random voltage fluctuations,
+  \texttt{V = RandGaus(1., pm_voltage_variation)}.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+data:
+  - type: double
+    units: dimensionless
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/qe_variation.schema.yml
+++ b/schemas/qe_variation.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for qe_variation model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: qe_variation
+developer_note: |-
+  DISCUSS - rename to make clear this parameter is used for all
+  photodetectors (not PMTs only).
+description: |-
+  Variation of quantum or photon detection efficiency
+  (Gaussian r.m.s. spread of random fluctuations) between
+  photo detectors in a given camera. Given in fraction of
+  the average quantum or photon detection efficiency; the variation
+  is applied independent of the wavelength.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  type: double
+  allowed_range:
+    min: 0.0
+    max: 1.0
+  units: dimensionless
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraChargeResponse
+    - ValidateCameraGainsAndEfficiency
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/quantum_efficiency.schema.yml
+++ b/schemas/quantum_efficiency.schema.yml
@@ -1,0 +1,82 @@
+%YAML 1.2
+---
+title: Schema for quantum_efficiency model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: quantum_efficiency
+description: |-
+  Quantum or photon detection efficiency
+  averaged over all pixels per camera.
+  Random pixel-to-pixel variations are calculated using
+  the qe_variation parameter. Pixel-to-pixel differences
+  in detection efficiency using scaling factors can be
+  specified in the camera_config_file.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: datatable
+    table_columns:
+      - name: wavelength
+        description: Wavelength.
+        required: true
+        units: nm
+        type: double
+        required_range:
+          min: 300.0
+          max: 700.0
+        input_processing:
+          - remove_duplicates
+          - sort
+      - name: photo_detection_efficiency
+        description: Average quantum or photon detection efficiency.
+        required: true
+        units: dimensionless
+        type: double
+        allowed_range:
+          min: 0.0
+          max: 1.0
+      - name: sigma
+        description: r.m.s. of individual PDE values.
+        required: false
+        units: dimensionless
+        type: double
+        allowed_range:
+          min: 0.0
+          max: 1.0
+      - name: pde_min
+        description: Minimum detection efficiency of the photo detector sample.
+        required: false
+        units: dimensionless
+        type: double
+        allowed_range:
+          min: 0.0
+          max: 1.0
+      - name: pde_max
+        description: Maximum detection efficiency of the photo detector sample.
+        required: false
+        units: dimensionless
+        type: double
+        allowed_range:
+          min: 0.0
+          max: 1.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraChargeResponse
+    - ValidateCameraGainsAndEfficiency
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/random_focal_length.schema.yml
+++ b/schemas/random_focal_length.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for random_focal_length model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: random_focal_length
+developer_note: Note - Description changed significantly in the sim_telarray manual
+  - Note
+description: |-
+  The spread of random fluctuations in mirror panel focal lengths.
+  These parameters get only applied if the focal lengths in the mirror list
+  file (par:mirror_list) are zero (automatic) or negative (individual with
+  error). For positive focal lengths in that list (definite values) the
+  random focal length value does not get applied.
+short_description: The spread of random fluctuations in mirror focal lengths.
+data:
+  - type: double
+    description: Width (r.m.s.) of Gaussian distribution for random focal lengths.
+    units: cm
+    default: 7.4
+    condition: mirror_class==1
+  - type: double
+    description: Width of top-hat distribution for random focal lengths.
+    units: cm
+    default: 0.0
+    condition: mirror_class==1
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateMirrorPanelParameters
+    - ValidateOpticalPSF
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/ref_lat.schema.yml
+++ b/schemas/ref_lat.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for ref_lat model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: ref_lat
+description: |-
+  Latitude of site centre.
+  Telescope x,y positions are calculated relative to this
+  position.
+short_description: Latitude of site centre.
+data:
+  - type: double
+    units: deg
+    allowed_range:
+      min: -90.0
+      max: 90.0
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/schemas/ref_long.schema.yml
+++ b/schemas/ref_long.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for ref_long model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: ref_long
+description: |-
+  Longitude of site centre.
+  Telescope x,y positions are calculated relative to this
+  position.
+short_description: Longitude of site centre.
+data:
+  - type: double
+    units: deg
+    allowed_range:
+      min: -180.0
+      max: 180.0
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/schemas/secondary_baffle.schema.yml
+++ b/schemas/secondary_baffle.schema.yml
@@ -1,0 +1,75 @@
+%YAML 1.2
+---
+title: Schema for secondary_baffle model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: secondary_baffle
+description: |-
+  Defines a baffle around the secondary mirror to keep NSB light from
+  falling directly onto the camera. Shadowing by the baffle is applied
+  both to incoming photons and to photons reflected from the primary
+  to the secondary mirror. Absence of a baffle is indicated by $r_1=0$.
+short_description: |-
+  Defines a baffle around the secondary mirror to keep NSB light from
+  falling directly onto the camera.
+data:
+  - name: baffle_z1
+    description: |-
+      Beginning of the baffle along the optical axis, counted from the
+      primary center, which means a z value of par:secondary_ref_radius
+      times the first par:secondary_mirror_parameters value is at the
+      height of the center of the secondary.
+    type: double
+    units: cm
+    required: true
+    condition: mirror_class==2
+  - name: baffle_z2
+    description: |-
+      End of the baffle along the optical axis, counted from the
+      primary center, which means a z value of par:secondary_ref_radius
+      times the first par:secondary_mirror_parameters value is at the
+      height of the center of the secondary.
+    type: double
+    units: cm
+    required: true
+    condition: mirror_class==2
+  - name: radius_r1
+    description: Radius of open cylinder shape or cone shape at baffle_z1.
+    type: double
+    units: cm
+    required: true
+    condition: mirror_class==2
+  - name: thickness_d1
+    description: |-
+      Wall thickness of the baffle. The radius radius_r1 and radius_r2
+      are the inner radii in case of finite wall thickness.
+    type: double
+    units: cm
+    required: false
+    condition: mirror_class==2
+  - name: radius_r2
+    description: Radius of open cylinder shape or cone shape at baffle_z2.
+    type: double
+    units: cm
+    required: false
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateTelescopeEfficiency
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/secondary_shadow_diameter.schema.yml
+++ b/schemas/secondary_shadow_diameter.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for secondary_shadow_diameter model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: secondary_shadow_diameter
+description: |-
+  The diameter of any non-reflective but not transparent (black)
+  central part of the secondary mirror in a dual-mirror telescope.
+  A value of $-1$ indicates that the same value as for the
+  reflective diameter of the secondary (par:secondary-diameter) is
+  to be used.
+short_description: |-
+  The diameter of any non-reflective but not transparent (black)
+  central part of the secondary mirror in a dual-mirror telescope.
+data:
+  - type: double
+    units: cm
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeShadowing
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/secondary_shadow_offset.schema.yml
+++ b/schemas/secondary_shadow_offset.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for secondary_shadow_offset model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: secondary_shadow_offset
+description: |-
+  The secondary mirror shadowing element is normally assumed at the level
+  of the edge of the secondary.  If this parameter is non-zero, it can be
+  set at any position above the center of the primary mirror.
+  Even if placed in front of the secondary, it will not be used for
+  photons reflected from the secondary.
+short_description: |-
+  The offset of the shadowing element from the level of the edge of the
+  secondary mirror.
+data:
+  - type: double
+    units: cm
+    default: 0.0
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateTelescopeShadowing
+    - ValidateTelescopeEfficiency
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/telescope_axes_height.schema.yml
+++ b/schemas/telescope_axes_height.schema.yml
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+title: Schema for telescope_axes_height model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: telescope_axes_height
+description: Height of telescope axes above ground level.
+data:
+  - type: double
+    units: m
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidationWorkflowMissing
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/schemas/telescope_random_angle.schema.yml
+++ b/schemas/telescope_random_angle.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for telescope_random_angle model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: telescope_random_angle
+description: |-
+  Random (known) misalignment of the telescope in each axis
+  (Gaussian r.m.s.). The resulting telescope pointing including
+  this misalignment are saved as telescope azimuth and altitude
+  pointing directions.
+data:
+  - type: double
+    units: deg
+    default: 0.005
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidationWorkflowMissing
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/telescope_random_error.schema.yml
+++ b/schemas/telescope_random_error.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for telescope_random_error model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: telescope_random_error
+description: |-
+  Random (unknown) alignment error of the telescope in each axis
+  (Gaussian r.m.s.). The resulting telescope pointing including
+  this misalignment is not saved to the simulation output.
+data:
+  - type: double
+    units: deg
+    default: 0.001
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidationWorkflowMissing
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/telescope_sphere_radius.schema.yml
+++ b/schemas/telescope_sphere_radius.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for telescope_sphere_radius model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: telescope_sphere_radius
+developer_note: |-
+  Part of `array_coordinates` in CORSIKA.
+  Required to set fiducial sphere center at correct height above ground.
+  TODO - define validation workflow (e.g., compare image size of MC and
+  data; same as for `telescope_sphere_radius`)
+  Note the axes_offset in the calculation of the sphere radius.
+description: Telescope fiducial sphere radius.
+data:
+  - type: double
+    units: m
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeFiducialSphere
+  validation:
+    - ValidateParameterByExpert
+    - ValidationWorkflowMissing
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/schemas/telescope_transmission.schema.yml
+++ b/schemas/telescope_transmission.schema.yml
@@ -1,0 +1,110 @@
+%YAML 1.2
+---
+title: Schema for telescope_transmission model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: telescope_transmission
+developer_note: |-
+  If compiled with the \texttt{RAYTRACING_INTERSECT_RODS} pre-processor
+  definition, the default value is 1.00, as the absorption is
+  calculated explicitly.
+description: |-
+  Off-axis angle-dependent transmission, accounting for absorption and
+  shadowing by masts.  Two types of functions are available, a constant
+  and a variable one ($T(\theta)$), where the former is selected
+  if transmission_function = 0 and the latter if transmission_function = 1.
+  Two options are available for the variable function, it is defined as
+  \[
+  T(\theta)=p_0/(1.+p_2 ((\sin\theta)/r_3)^{p_4}),
+  \]
+  if $p_5=0$, and as
+  \[
+  T(\theta)=p_0/(1.+p_2 ((\sin\theta)/r_3)^{p_4})^{p_5},
+  \]
+  if $p_5\ne0$.
+  The parameter $r_3$ is defined as $r_3=p_3 \pi/180$ and
+  $p_0$, $p_2$, $p_3$, $p_4$ and $p_5$
+  are the first, third, fourth, fifth and sixth parameters.
+  Default values are $p_4=2$, $p_3=0.5 d/f$ when these are missing/zero.
+  The $p_5$ parameter may not be available/supported and is effectively
+  zero/unused if not.
+  A value of $p_0 = 0.89$ means that 11\% of all light is assumed to be
+  absorbed by masts.
+  Shadowing by camera body is accounted for later
+  (see parameter par:camera-body-diameter and par:camera-depth).
+short_description: |-
+  Off-axis angle-dependent transmission, accounting for absorption and
+  shadowing by masts.
+data:
+  - name: constant_p0
+    type: double
+    description: |
+      Constant transmission factor $p_0$.
+    required: true
+    units: dimensionless
+    default: 0.89
+    allowed_range:
+      min: 0.0
+      max: 1.0
+  - name: transmission_function
+    required: false
+    type: uint
+    description: |
+      Transmission function identifier.
+    default: 0
+    allowed_range:
+      min: 0
+      max: 1
+    units: dimensionless
+  - name: transmission_p2
+    description: |
+      Transmission factor $p_2$.
+    required: false
+    type: double
+    default: 0.0
+    units: dimensionless
+  - name: transmission_p3
+    description: |
+      Transmission factor $p_3$.
+    required: false
+    type: double
+    default: 0.0
+    units: dimensionless
+  - name: transmission_p4
+    description: |
+      Transmission factor $p_4$.
+    required: false
+    type: double
+    default: 0.0
+    units: dimensionless
+  - name: transmission_p5
+    description: |
+      Transmission factor $p_5.
+    required: false
+    type: double
+    default: 0.0
+    units: dimensionless
+instrument:
+  class: Structure
+  type:
+    - LSTStructure
+    - MSTStructure
+    - SSTStructure
+    - SCTStructure
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeShadowingParameters
+    - SetTelescopeEfficiency
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeShadowing
+    - ValidateTriggerPerformance
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/schemas/teltrig_min_sigsum.schema.yml
+++ b/schemas/teltrig_min_sigsum.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for teltrig_min_sigsum model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: teltrig_min_sigsum
+description: |-
+  Minimum signal sum at sector trigger over threshold.
+  Note that both the minimum time over threshold and the minimum signal
+  sum have to be satisfied before a trigger is obtained. Normally, either
+  of these values being non-zero should be sufficient.
+short_description: Minimum signal sum at sector trigger over threshold.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: mV * ns
+    default: 7.8
+    allowed_range:
+      min: 0.0
+      max: 1000.0
+    condition: default_trigger==Majority
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/teltrig_min_time.schema.yml
+++ b/schemas/teltrig_min_time.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for teltrig_min_time model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: teltrig_min_time
+description: Minimum time of sector trigger over threshold.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    default: 1.5
+    allowed_range:
+      min: 0.0
+      max: 10.0
+    condition: default_trigger==Majority
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/transit_time_calib_error.schema.yml
+++ b/schemas/transit_time_calib_error.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for transit_time_calib_error model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: transit_time_calib_error
+description: |-
+  Accuracy with which the actual signal delay due to transit
+  time variation and corresponding compensation can be determined.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/transit_time_compensate_error.schema.yml
+++ b/schemas/transit_time_compensate_error.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for transit_time_compensate_error model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: transit_time_compensate_error
+description: |-
+  Additional error (r.m.s.) in how well the number of steps for
+  transit time compensation can be determined before the
+  compensation is applied.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/transit_time_compensate_step.schema.yml
+++ b/schemas/transit_time_compensate_step.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for transit_time_compensate_step model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: transit_time_compensate_step
+description: |-
+  If signal delays can be compensated independent of the sampling,
+  this is the time step in which this compensation can be done.
+  A value of zero means no compensation is applied.
+  The same compensation is applied to all channels.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/transit_time_error.schema.yml
+++ b/schemas/transit_time_error.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for transit_time_error model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: transit_time_error
+short_description: Errors (r.m.s.) in transit time, not related to high voltage.
+description: |-
+  Errors (r.m.s.) in transit time, additionally to and not related to
+  those depending on applied high voltage.
+  If this parameter is set to $-1$, the readout interval is assumed to be
+  adjusted, pixel by pixel, such that resulting transit time differences
+  are within one readout time slice. For correcting transit times by
+  electronic means with time steps independent of the sampling frequency the
+  par:transit-time-compensate-step and par:transit-time-compensate-error
+  can be used.  The resulting transit time difference, after application of
+  compensation if used, is reported in the calibration data block, but only
+  up to a random accuracy defined by par:transit-time-calib-error.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    allowed_range:
+      min: -1.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/transit_time_jitter.schema.yml
+++ b/schemas/transit_time_jitter.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for transit_time_jitter model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: transit_time_jitter
+description: |-
+  Time jitter (Gaussian r.m.s. spread of random fluctuations) of individual
+  photo-electrons.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: ns
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/schemas/trigger_current_limit.schema.yml
+++ b/schemas/trigger_current_limit.schema.yml
@@ -1,0 +1,31 @@
+%YAML 1.2
+---
+title: Schema for trigger_current_limit model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: trigger_current_limit
+description: Pixels above this limit are excluded from the trigger.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    units: uA
+    default: 20.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/trigger_decision_circuitry.schema.yml
+++ b/schemas/trigger_decision_circuitry.schema.yml
@@ -1,0 +1,59 @@
+%YAML 1.2
+---
+title: Schema for trigger_decision_circuitry model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: trigger_decision_circuitry
+developer_note: |-
+  Part of sim_telarray camera configuration file (TRIGGER lines).
+  TODO - discuss usage of anyOf / allOf in this context.
+description: List specifying the circuitry for trigger decisions per pixel group.
+data:
+  - type: datatable
+    name: majority_trigger
+    description: Majority trigger definition.
+    table_columns:
+      - name: majority_trigger_line
+        description: Majority trigger statement.
+        type: string
+        units: dimensionless
+        required: false
+  - type: datatable
+    name: analog_sum_trigger
+    description: Analog sum trigger definition.
+    table_columns:
+      - name: asum_trigger_line
+        description: Analog sum trigger statement.
+        type: string
+        required: false
+        units: dimensionless
+  - type: datatable
+    name: Digital_sum_trigger
+    description: Digital sum trigger definition.
+    table_columns:
+      - name: dsum_trigger_line
+        description: Digital sum trigger statement.
+        type: string
+        required: false
+        units: dimensionless
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/trigger_delay_compensation.schema.yml
+++ b/schemas/trigger_delay_compensation.schema.yml
@@ -1,0 +1,48 @@
+%YAML 1.2
+---
+title: Schema for trigger_delay_compensation model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: trigger_delay_compensation
+developer_note: Always zero for all cameras.
+description: |-
+  The majority trigger, analog sum trigger, and digital sum trigger
+  decisions result in different times of the trigger decision. To
+  compensate for this, a delay is applied for array-level coincidences
+  of triggers from telescopes with different trigger types.
+short_description: |-
+  The delay applied to the trigger output to compensate for the different
+  execution times of each trigger algorithm.
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - FlashCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+data:
+  - type: double
+    description: Delay applied for majority trigger.
+    units: ns
+    default: 0.0
+  - type: double
+    description: Delay applied for analog sum trigger.
+    units: ns
+    default: 0.0
+  - type: double
+    description: Delay applied for digital sum trigger.
+    units: ns
+    default: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/schemas/trigger_pixels.schema.yml
+++ b/schemas/trigger_pixels.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for trigger_pixels model parameter
+version: 0.1.0
+base_schema: simpipe-schema
+base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_version: 0.1.0
+name: trigger_pixels
+description: |-
+  Number of pixels required for single telescope trigger.
+  With flexible camera definitions, this is the default number for the
+  multiplicity required per trigger group. Any definition of trigger groups
+  (e.g., parameter DigitalSumTrigger) overwrites the setting of
+  trigger_pixels.
+short_description: Number of pixels required for single telescope trigger.
+data:
+  - type: uint
+    units: dimensionless
+    default: 4
+instrument:
+  class: Camera
+  type:
+    - LSTCam
+    - NectarCam
+    - SSTCam
+    - SCTCam
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray


### PR DESCRIPTION
This pull requests:

- copies schemas for all model parameters from the internal gitlab repository (no change to any of the yaml files)
- added a sentence to [schemas/README.md](schemas/README.md) that the descriptions are copied / synced with the simtel_array manual
- added KB to the list of authors in CITATION.cff
- extended the line lenght of yamllint to 100 (as I didn't not want to change the schema yaml files).

So only the README.md and CITATION.cff needs to be reviewed. Further updates to the parameter schema files (as discussed in our meetings) will be done in future pull requests.