### PR TITLE
Rename column 'alt' to 'altitude' in UTM telescope list schema

### DIFF
--- a/schemas/array_coordinates_UTM.schema.yml
+++ b/schemas/array_coordinates_UTM.schema.yml
@@ -39,7 +39,7 @@ data:
         units: m
         input_processing:
           - allow_nan
-      - name: alt
+      - name: altitude
         description: |-
           Altitude of the array element.
         required: true


### PR DESCRIPTION
We have agreed a while ago to be explicit in the naming and avoid wherever possible abbreviations.

This pull requests renames `alt` to `altitude` in the UTM telescope list file name. In all other schemas, this has already done a while ago (and simtools:layout:telescope_list expect as well a keyword altitude).

(and yes, the workflows/schemas is temporary and will be move to the simulation_model repository and/or database. For now, this change is necessary to allow unit tests in simtools to pass)