### PR TITLE
Rename `base_schema` to `meta_schema`

### DIFF
--- a/schemas/MST_mirror_2f_measurements.schema.yml
+++ b/schemas/MST_mirror_2f_measurements.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for mirror panel 2F measurements
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: mirror_2f_measurement
 description: |-
   Mirror panel 2F measurements determining

--- a/schemas/altitude.schema.yml
+++ b/schemas/altitude.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for altitude model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: altitude
 description: |-
   Altitude above sea level of site centre.

--- a/schemas/array_coordinates.schema.yml
+++ b/schemas/array_coordinates.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for array_coordinates model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: array_coordinates
 description: Telescope positions.
 data:

--- a/schemas/array_coordinates_UTM.schema.yml
+++ b/schemas/array_coordinates_UTM.schema.yml
@@ -39,7 +39,7 @@ data:
         units: m
         input_processing:
           - allow_nan
-      - name: alt
+      - name: altitude
         description: |-
           Altitude of the array element.
         required: true

--- a/schemas/array_coordinates_UTM.schema.yml
+++ b/schemas/array_coordinates_UTM.schema.yml
@@ -39,7 +39,7 @@ data:
         units: m
         input_processing:
           - allow_nan
-      - name: altitude
+      - name: alt
         description: |-
           Altitude of the array element.
         required: true

--- a/schemas/array_coordinates_UTM.schema.yml
+++ b/schemas/array_coordinates_UTM.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for array_coordinates_utm input data
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: array_coordinates_utm
 description: |-
   Array elements (e.g., telescope positions) in UTM coordinates.

--- a/schemas/asum_clipping.schema.yml
+++ b/schemas/asum_clipping.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for asum_clipping model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: asum_clipping
 description: |-
   The amplitude level at which the signal from each pixel

--- a/schemas/asum_offset.schema.yml
+++ b/schemas/asum_offset.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for asum_offset model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: asum_offset
 description: Offset in time where shaping convolution is done.
 instrument:

--- a/schemas/asum_shaping.schema.yml
+++ b/schemas/asum_shaping.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for asum_shaping model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: asum_shaping
 description: |-
   Shaping (convolution) parameters for an input photo detector signal to the

--- a/schemas/asum_threshold.schema.yml
+++ b/schemas/asum_threshold.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for asum_threshold model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: asum_threshold
 description: |-
   The amplitude level above which an analog sum leads to a telescope

--- a/schemas/atmospheric_profile.schema.yml
+++ b/schemas/atmospheric_profile.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for atmospheric_profile model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: atmospheric_profile
 developer_note: TODO - clarify if steps in and range of altitude are fixed.
 description: Density, thickness, and index of refraction as function of altitude.

--- a/schemas/atmospheric_transmission.schema.yml
+++ b/schemas/atmospheric_transmission.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for atmospheric_transmission model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: atmospheric_transmission
 developer_note: |-
   TODO - crosscheck required range

--- a/schemas/axes_offsets.schema.yml
+++ b/schemas/axes_offsets.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for axes_offsets model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: axes_offsets
 description: |-
   Geometric offsets to be used in case that the azimuth, altitude, and

--- a/schemas/camera_body_diameter.schema.yml
+++ b/schemas/camera_body_diameter.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for camera_body_diameter model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: camera_body_diameter
 description: |-
   Diameter of camera body (used to account for effects of shadowing).

--- a/schemas/camera_body_shape.schema.yml
+++ b/schemas/camera_body_shape.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for camera_body_shape model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: camera_body_shape
 description: |-
   Code for the shape of the camera,

--- a/schemas/camera_config_pixel.schema.yml
+++ b/schemas/camera_config_pixel.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for camera_config_pixel model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: camera_config_pixel
 developer_note: |-
   Part of sim_telarray camera_config_file (parameter Pixel).

--- a/schemas/camera_config_pixel_type.schema.yml
+++ b/schemas/camera_config_pixel_type.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for camera_config_pixel_type model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: camera_config_pixel_type
 developer_note: Part of sim_telarray camera_config_file (parameter PixType).
 description: |-

--- a/schemas/camera_config_rotate.schema.yml
+++ b/schemas/camera_config_rotate.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for camera_config_rotate model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: camera_config_rotate
 developer_note: Part of sim_telarray camera_config_file (parameter Rotate).
 description: |-

--- a/schemas/camera_depth.schema.yml
+++ b/schemas/camera_depth.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for camera_depth model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: camera_depth
 description: |-
   Depth of a camera body, used for shadowing.

--- a/schemas/camera_filter.schema.yml
+++ b/schemas/camera_filter.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for camera_filter model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: camera_filter
 developer_note: |-
   Note - describes both 2D and 3D tables

--- a/schemas/camera_pixels.schema.yml
+++ b/schemas/camera_pixels.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for camera_pixels model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: camera_pixels
 description: Number of pixels in the camera.
 data:

--- a/schemas/camera_transmission.schema.yml
+++ b/schemas/camera_transmission.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for camera_transmission model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: camera_transmission
 description: |-
   Global wavelength-independent transmission factor of the camera,

--- a/schemas/camera_type.schema.yml
+++ b/schemas/camera_type.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for camera_type model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: camera_type
 developer_note: |-
   TODO - The option of flexible camera configuration is the

--- a/schemas/default_trigger.schema.yml
+++ b/schemas/default_trigger.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for default_trigger model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: default_trigger
 description: Trigger algorithm used.
 instrument:

--- a/schemas/disc_ac_coupled.schema.yml
+++ b/schemas/disc_ac_coupled.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for disc_ac_coupled model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: disc_ac_coupled
 description: Discriminators/comparator are AC coupled (if true).
 short_description: Control AC coupling of the discriminators.

--- a/schemas/disc_bins.schema.yml
+++ b/schemas/disc_bins.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for disc_bins model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: disc_bins
 description: |-
   Number of time bins used for the discriminator or comparator simulation.

--- a/schemas/disc_start.schema.yml
+++ b/schemas/disc_start.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for disc_start model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: disc_start
 description: |-
   Number of time bins by which the discriminator or comparator simulation

--- a/schemas/discriminator_amplitude.schema.yml
+++ b/schemas/discriminator_amplitude.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_amplitude model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_amplitude
 developer_note: |-
   TODO - Units of mV are always used for CTA. Expect that this will

--- a/schemas/discriminator_fall_time.schema.yml
+++ b/schemas/discriminator_fall_time.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_fall_time model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_fall_time
 description: |-
   Fall time of discriminator/comparator output after the logical output

--- a/schemas/discriminator_gate_length.schema.yml
+++ b/schemas/discriminator_gate_length.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_gate_length model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_gate_length
 description: |-
   Effective discriminator gate length. To achieve a comparator-type

--- a/schemas/discriminator_hysteresis.schema.yml
+++ b/schemas/discriminator_hysteresis.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_hysteresis model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_hysteresis
 description: |-
   The switching off of a comparator is normally with some hysteresis to

--- a/schemas/discriminator_output_amplitude.schema.yml
+++ b/schemas/discriminator_output_amplitude.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_output_amplitude model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_output_amplitude
 description: |-
   The nominal output amplitude of a pixel discriminator or comparator as

--- a/schemas/discriminator_output_var_percent.schema.yml
+++ b/schemas/discriminator_output_var_percent.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_output_var_percent model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_output_var_percent
 description: |-
   Channel-to-channel variation (Gaussian r.m.s.) of the output amplitude

--- a/schemas/discriminator_pulse_shape.schema.yml
+++ b/schemas/discriminator_pulse_shape.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_pulse_shape model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_pulse_shape
 description: Pulse shape at the discriminator/comparator of an individual pixel.
 instrument:

--- a/schemas/discriminator_rise_time.schema.yml
+++ b/schemas/discriminator_rise_time.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_rise_time model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_rise_time
 description: |-
   Rise time of the discriminator/comparator output. After the

--- a/schemas/discriminator_sigsum_over_threshold.schema.yml
+++ b/schemas/discriminator_sigsum_over_threshold.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_sigsum_over_threshold model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_sigsum_over_threshold
 developer_note: |-
   Intended as mV * ns, but if unit of

--- a/schemas/discriminator_threshold.schema.yml
+++ b/schemas/discriminator_threshold.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_threshold model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_threshold
 description: Discriminator/comparator threshold.
 instrument:

--- a/schemas/discriminator_time_over_threshold.schema.yml
+++ b/schemas/discriminator_time_over_threshold.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_time_over_threshold model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_time_over_threshold
 description: |-
   Time over threshold required before logic response switches to true.

--- a/schemas/discriminator_var_gate_length.schema.yml
+++ b/schemas/discriminator_var_gate_length.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_var_gate_length model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_var_gate_length
 description: |-
   Variation of gate length (Gaussian r.m.s.). In comparator-type

--- a/schemas/discriminator_var_sigsum_over_threshold.schema.yml
+++ b/schemas/discriminator_var_sigsum_over_threshold.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_var_sigsum_over_threshold model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_var_sigsum_over_threshold
 developer_note: |-
   Intended as mV * ns, but if unit of

--- a/schemas/discriminator_var_threshold.schema.yml
+++ b/schemas/discriminator_var_threshold.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_var_threshold model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_var_threshold
 description: |-
   Channel-to-channel variations (random Gaussian r.m.s.) of

--- a/schemas/discriminator_var_time_over_threshold.schema.yml
+++ b/schemas/discriminator_var_time_over_threshold.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for discriminator_var_time_over_threshold model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: discriminator_var_time_over_threshold
 description: |-
   Pixel-to-pixel variation of the time over threshold required before logic

--- a/schemas/dish_shape_length.schema.yml
+++ b/schemas/dish_shape_length.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dish_shape_length model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dish_shape_length
 description: |-
   Dish curvature length, best equal to focal length. For a Davies-Cotton

--- a/schemas/dsum_clipping.schema.yml
+++ b/schemas/dsum_clipping.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_clipping model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_clipping
 description: |-
   The amplitude level (in ADC counts above pedestal) at which the digitized

--- a/schemas/dsum_ignore_below.schema.yml
+++ b/schemas/dsum_ignore_below.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_ignore_below model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_ignore_below
 description: |-
   FADC signals (pedestal subtracted and/or shaped) below this value,

--- a/schemas/dsum_offset.schema.yml
+++ b/schemas/dsum_offset.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_offset model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_offset
 description: |-
   Offset in time where digital pulse shaping is done. Time intervals at

--- a/schemas/dsum_pedsub.schema.yml
+++ b/schemas/dsum_pedsub.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_pedsub model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_pedsub
 description: |-
   Expected pedestal is first subtracted before any

--- a/schemas/dsum_pre_clipping.schema.yml
+++ b/schemas/dsum_pre_clipping.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_pre_clipping model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_pre_clipping
 description: |-
   The amplitude level (in ADC counts above pedestal)

--- a/schemas/dsum_prescale.schema.yml
+++ b/schemas/dsum_prescale.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_prescale model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_prescale
 developer_note: TODO - Remove comment on DDSUM_DOUBLE?
 description: |-

--- a/schemas/dsum_presum_max.schema.yml
+++ b/schemas/dsum_presum_max.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_presum_max model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_presum_max
 description: |-
   After bit-shifting the pre-sum, the resulting value

--- a/schemas/dsum_presum_shift.schema.yml
+++ b/schemas/dsum_presum_shift.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_presum_shift model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_presum_shift
 description: |-
   After a patch-wise pre-summation, the resulting sum may be

--- a/schemas/dsum_shaping.schema.yml
+++ b/schemas/dsum_shaping.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_shaping model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_shaping
 description: |-
   Shaping (convolution) parameters for a digitized detector signal

--- a/schemas/dsum_shaping_renormalize.schema.yml
+++ b/schemas/dsum_shaping_renormalize.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_shaping_renormalize model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_shaping_renormalize
 description: |-
   The positive part of the shaping kernel is auto-normalized

--- a/schemas/dsum_threshold.schema.yml
+++ b/schemas/dsum_threshold.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_threshold model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_threshold
 description: |-
   The amplitude level above pedestal sum above which a

--- a/schemas/dsum_zero_clip.schema.yml
+++ b/schemas/dsum_zero_clip.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dsum_zero_clip model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dsum_zero_clip
 description: |-
   With a value of 1, any negative shaped signals are clipped at zero

--- a/schemas/dual_mirror_diameter.schema.yml
+++ b/schemas/dual_mirror_diameter.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dual_mirror_diameter model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dual_mirror_diameter
 description: |-
   The outer diameter of the primary and secondary reflectors.

--- a/schemas/dual_mirror_hole_diameter.schema.yml
+++ b/schemas/dual_mirror_hole_diameter.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dual_mirror_hole_diameter model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dual_mirror_hole_diameter
 description: |-
   The diameter of any non-reflective part of the primary or

--- a/schemas/dual_mirror_parameters.schema.yml
+++ b/schemas/dual_mirror_parameters.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dual_mirror_parameters model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dual_mirror_parameters
 developer_note: |-
   Note the application of dual_mirror_ref_radius (primary_ref_radius,

--- a/schemas/dual_mirror_ref_radius.schema.yml
+++ b/schemas/dual_mirror_ref_radius.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dual_mirror_ref_radius model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dual_mirror_ref_radius
 description: |-
   The length scale to which the dual_mirror_parameters apply.

--- a/schemas/dual_mirror_segmentation.schema.yml
+++ b/schemas/dual_mirror_segmentation.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for dual_mirror_segmentation model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: dual_mirror_segmentation
 developer_note: |-
   Defined in a sim_telarray configuration file

--- a/schemas/effective_focal_length.schema.yml
+++ b/schemas/effective_focal_length.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for effective_focal_length model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: effective_focal_length
 developer_note: |-
   Not a simulation model parameter but used for the analysis only.

--- a/schemas/epsg_code.schema.yml
+++ b/schemas/epsg_code.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for epsg_code model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: epsg_code
 developer_note: |-
   Obtained from https://epsg.io/32628 and

--- a/schemas/fadc_ac_coupled.schema.yml
+++ b/schemas/fadc_ac_coupled.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_ac_coupled model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_ac_coupled
 description: |-
   AC coupling of the FADCs.  If set to 1, then FADCs are AC coupled.

--- a/schemas/fadc_amplitude.schema.yml
+++ b/schemas/fadc_amplitude.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_amplitude model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_amplitude
 description: |-
   Peak amplitude at ADC/FADC.

--- a/schemas/fadc_bins.schema.yml
+++ b/schemas/fadc_bins.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_bins model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_bins
 description: |-
   Number of FADC bins to be simulated.

--- a/schemas/fadc_dev_pedestal.schema.yml
+++ b/schemas/fadc_dev_pedestal.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_dev_pedestal model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_dev_pedestal
 developer_note: |-
   Not applicable for CTA telescopes.

--- a/schemas/fadc_err_pedestal.schema.yml
+++ b/schemas/fadc_err_pedestal.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_err_pedestal model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_err_pedestal
 developer_note: |-
   TODO - check if this is relevant as this affects only the reported

--- a/schemas/fadc_max_signal.schema.yml
+++ b/schemas/fadc_max_signal.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_max_signal model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_max_signal
 description: |-
   Maximum value of digitized signal per sample.

--- a/schemas/fadc_max_sum.schema.yml
+++ b/schemas/fadc_max_sum.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_max_sum model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_max_sum
 developer_note: Not applicable for CTA telescopes.
 description: |-

--- a/schemas/fadc_mhz.schema.yml
+++ b/schemas/fadc_mhz.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_mhz model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_mhz
 description: FADC sampling rate.
 data:

--- a/schemas/fadc_noise.schema.yml
+++ b/schemas/fadc_noise.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_noise model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_noise
 description: |-
   Gaussian r.m.s. spread of white noise per time bin in digitisation

--- a/schemas/fadc_pedestal.schema.yml
+++ b/schemas/fadc_pedestal.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_pedestal model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_pedestal
 description: (F)ADC pedestal value per time slice.
 data:

--- a/schemas/fadc_pulse_shape.schema.yml
+++ b/schemas/fadc_pulse_shape.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_pulse_shape model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_pulse_shape
 description: |-
   (F)ADC pulse shape (amplitude vs time) for low and high gain

--- a/schemas/fadc_sensitivity.schema.yml
+++ b/schemas/fadc_sensitivity.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_sensitivity model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_sensitivity
 developer_note: |-
   DISCUSS - suggest to fix this to 1. for CTA and enforce

--- a/schemas/fadc_sum_bins.schema.yml
+++ b/schemas/fadc_sum_bins.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_sum_bins model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_sum_bins
 description: |-
   Number of bins summed up in ADC sum data or read out in sampled data.

--- a/schemas/fadc_sum_offset.schema.yml
+++ b/schemas/fadc_sum_offset.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_sum_offset model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_sum_offset
 description: |-
   Number of bins before telescope trigger where summing or reading of

--- a/schemas/fadc_sysvar_pedestal.schema.yml
+++ b/schemas/fadc_sysvar_pedestal.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_sysvar_pedestal model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_sysvar_pedestal
 description: |-
   Systematic common (e.g. due to temperature) variation of pedestals.

--- a/schemas/fadc_var_pedestal.schema.yml
+++ b/schemas/fadc_var_pedestal.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_var_pedestal model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_var_pedestal
 description: |-
   Channel-to-channel (or pixel-to-pixel) variation of the pedestal per FADC

--- a/schemas/fadc_var_sensitivity.schema.yml
+++ b/schemas/fadc_var_sensitivity.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for fadc_var_sensitivity model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: fadc_var_sensitivity
 description: Relative variations in sensitivity (even for FADCs of the same channel).
 data:

--- a/schemas/flatfielding.schema.yml
+++ b/schemas/flatfielding.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for flatfielding model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: flatfielding
 developer_note: |-
   This is of integer type in sim_telarray with allowed values 0 and 1.

--- a/schemas/focal_length.schema.yml
+++ b/schemas/focal_length.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for focal_length model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: focal_length
 description: |-
   Nominal overall focal length of the entire telescope. This defines the

--- a/schemas/focal_surface_parameters.schema.yml
+++ b/schemas/focal_surface_parameters.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for focal_surface_parameters model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: focal_surface_parameters
 description: |-
   Defines the position of the focal surface along the optical axis and

--- a/schemas/focal_surface_ref_radius.schema.yml
+++ b/schemas/focal_surface_ref_radius.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for focal_surface_ref_radius model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: focal_surface_ref_radius
 description: The length scale to which the focal_surface_parameters apply.
 data:

--- a/schemas/focus_offset.schema.yml
+++ b/schemas/focus_offset.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for focus_offset model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: focus_offset
 description: |-
   Distance of the starlight focus from the camera pixels (light guides)

--- a/schemas/gain_variation.schema.yml
+++ b/schemas/gain_variation.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for gain_variation model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: gain_variation
 short_description: |-
   Fractional gain variation between different photo detectors after

--- a/schemas/hg_lg_variation.schema.yml
+++ b/schemas/hg_lg_variation.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for hg_lg_variation model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: hg_lg_variation
 description: |-
   Relative pixel-to-pixel variation of the ratio of high-gain to

--- a/schemas/lightguide_efficiency_vs_incident_angle.schema.yml
+++ b/schemas/lightguide_efficiency_vs_incident_angle.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for lightguide_efficiency_vs_incident_angle model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: lightguide_efficiency_vs_incident_angle
 developer_note: Part of sim_telarray camera_config_file (parameter PixType).
 description: |-

--- a/schemas/lightguide_efficiency_vs_wavelength.schema.yml
+++ b/schemas/lightguide_efficiency_vs_wavelength.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for lightguide_efficiency_vs_wavelength model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: lightguide_efficiency_vs_wavelength
 developer_note: |-
   The extra funnel efficiency table is interpreted such that

--- a/schemas/magnetic_field.schema.yml
+++ b/schemas/magnetic_field.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for magnetic_field model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: magnetic_field
 description: Geomagnetic field at given site.
 data:

--- a/schemas/mirror_align_random_distance.schema.yml
+++ b/schemas/mirror_align_random_distance.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for mirror_align_random_distance model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: mirror_align_random_distance
 description: |-
   Gaussian r.m.s. spread of random fluctuations in the aligned mirror

--- a/schemas/mirror_align_random_horizontal.schema.yml
+++ b/schemas/mirror_align_random_horizontal.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for mirror_align_random_horizontal model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: mirror_align_random_horizontal
 description: |-
   Fluctuations of the mirror alignment angle with respect to nominal

--- a/schemas/mirror_align_random_vertical.schema.yml
+++ b/schemas/mirror_align_random_vertical.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for mirror_align_random_vertical model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: mirror_align_random_vertical
 description: |-
   Fluctuations of the mirror alignment angle with respect to nominal

--- a/schemas/mirror_class.schema.yml
+++ b/schemas/mirror_class.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for mirror_class model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: mirror_class
 description: |-
   Parameter to control the type of mirror used.

--- a/schemas/mirror_focal_length.schema.yml
+++ b/schemas/mirror_focal_length.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for mirror_focal_length model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: mirror_focal_length
 description: |-
   Standard focal length of mirror tiles. This parameter is only used if

--- a/schemas/mirror_list.schema.yml
+++ b/schemas/mirror_list.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for mirror_list model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: mirror_list
 description: List of mirror positions, diameters, focal lengths, and shape codes.
 data:

--- a/schemas/mirror_offset.schema.yml
+++ b/schemas/mirror_offset.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for mirror_offset model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: mirror_offset
 description: |-
   Offset of mirror back plane from fixed point of telescope mount

--- a/schemas/mirror_reflection_random_angle.schema.yml
+++ b/schemas/mirror_reflection_random_angle.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for mirror_reflection_random_angle model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: mirror_reflection_random_angle
 description: |-
   Gaussian random fluctuations of reflection angles, due to

--- a/schemas/mirror_reflectivity.schema.yml
+++ b/schemas/mirror_reflectivity.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for mirror_reflectivity model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: mirror_reflectivity
 developer_note: |-
   Note - describes both 2D and 3D tables

--- a/schemas/multiplicity_offset.schema.yml
+++ b/schemas/multiplicity_offset.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for multiplicity_offset model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: multiplicity_offset
 description: |-
   This number tells where the actual threshold of the telescope trigger

--- a/schemas/night_sky_background_spectrum.schema.yml
+++ b/schemas/night_sky_background_spectrum.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for night_sky_background_spectrum model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: night_sky_background_spectrum
 developer_note: |
   TODO - check that wavelength range is sufficient

--- a/schemas/nightsky_background.schema.yml
+++ b/schemas/nightsky_background.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for nightsky_background model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: nightsky_background
 description: |-
   'Number of photo-electrons per nanosecond per pixel due to night-sky

--- a/schemas/nsb_gain_drop_scale.schema.yml
+++ b/schemas/nsb_gain_drop_scale.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for nsb_gain_drop_scale model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: nsb_gain_drop_scale
 description: |-
   This parameter, if non-zero, indicates the pixel p.e. rate at which the

--- a/schemas/nsb_offaxis.schema.yml
+++ b/schemas/nsb_offaxis.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for nsb_offaxis model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: nsb_offaxis
 description: |-
   Fall-off of NSB with off-axis angle due to change of effective optical

--- a/schemas/nsb_scaling_factor.schema.yml
+++ b/schemas/nsb_scaling_factor.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for nsb_scaling_factor model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: nsb_scaling_factor
 description: |-
   Common scaling of the NSB in all pixels of all telescopes against

--- a/schemas/nsb_sky_map.schema.yml
+++ b/schemas/nsb_sky_map.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for nsb_sky_map model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: nsb_sky_map
 description: |-
   An optional sky map (Az/Alt) of NSB enhancement factors, counted on top

--- a/schemas/num_gains.schema.yml
+++ b/schemas/num_gains.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for num_gains model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: num_gains
 description: Number of different gains the input signal gets digitized.
 data:

--- a/schemas/only_triggered_telescopes.schema.yml
+++ b/schemas/only_triggered_telescopes.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for only_triggered_telescopes model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: only_triggered_telescopes
 description: |-
   Triggered telescopes are read out only (if true), otherwise

--- a/schemas/parabolic_dish.schema.yml
+++ b/schemas/parabolic_dish.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for parabolic_dish model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: parabolic_dish
 description: |-
   Parabolic dish.

--- a/schemas/peak_sensing.schema.yml
+++ b/schemas/peak_sensing.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for peak_sensing model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: peak_sensing
 description: |-
   Report sample with the largest signal in the range otherwise

--- a/schemas/photon_delay.schema.yml
+++ b/schemas/photon_delay.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for photon_delay model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: photon_delay
 developer_note: |-
   Type corrected with respect to the sim_telarray manual

--- a/schemas/pixel_cells.schema.yml
+++ b/schemas/pixel_cells.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for pixel_cells model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: pixel_cells
 description: |-
   Modeling of pixel saturation. Value corresponds to the

--- a/schemas/pixels_parallel.schema.yml
+++ b/schemas/pixels_parallel.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for pixels_parallel model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: pixels_parallel
 description: |-
   Parameter controlling the orientation of the pixels, setting it to be

--- a/schemas/pixeltrg_time_step.schema.yml
+++ b/schemas/pixeltrg_time_step.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for pixeltrg_time_step model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: pixeltrg_time_step
 description: |-
   If non-zero, the time between the telescope trigger and the time

--- a/schemas/pm_average_gain.schema.yml
+++ b/schemas/pm_average_gain.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for pm_average_gain model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: pm_average_gain
 description: |-
   Photo detector average gain. Used to determine the DC currents

--- a/schemas/pm_collection_efficiency.schema.yml
+++ b/schemas/pm_collection_efficiency.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for pm_collection_efficiency model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: pm_collection_efficiency
 developer_note: Always set to 1. for CTA cameras.
 short_description: |-

--- a/schemas/pm_gain_index.schema.yml
+++ b/schemas/pm_gain_index.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for pm_gain_index model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: pm_gain_index
 description: |-
   PMT gain g and voltage U are assumed to be related by

--- a/schemas/pm_photoelectron_spectrum.schema.yml
+++ b/schemas/pm_photoelectron_spectrum.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for pm_photoelectron_spectrum model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: pm_photoelectron_spectrum
 description: |-
   Single photoelectron (p.e.) response distribution

--- a/schemas/pm_transit_time.schema.yml
+++ b/schemas/pm_transit_time.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for pm_transit_time model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: pm_transit_time
 description: Total transit time of the photodetector at the average voltage.
 instrument:

--- a/schemas/pm_voltage_variation.schema.yml
+++ b/schemas/pm_voltage_variation.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for pm_voltage_variation model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: pm_voltage_variation
 short_description: |-
   Fractional high voltage variation, used to adjust the transit time

--- a/schemas/qe_variation.schema.yml
+++ b/schemas/qe_variation.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for qe_variation model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: qe_variation
 developer_note: |-
   DISCUSS - rename to make clear this parameter is used for all

--- a/schemas/quantum_efficiency.schema.yml
+++ b/schemas/quantum_efficiency.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for quantum_efficiency model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: quantum_efficiency
 description: |-
   Quantum or photon detection efficiency

--- a/schemas/random_focal_length.schema.yml
+++ b/schemas/random_focal_length.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for random_focal_length model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: random_focal_length
 developer_note: Note - Description changed significantly in the sim_telarray manual
   - Note

--- a/schemas/ref_lat.schema.yml
+++ b/schemas/ref_lat.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for ref_lat model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: ref_lat
 description: |-
   Latitude of site centre.

--- a/schemas/ref_long.schema.yml
+++ b/schemas/ref_long.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for ref_long model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: ref_long
 description: |-
   Longitude of site centre.

--- a/schemas/secondary_baffle.schema.yml
+++ b/schemas/secondary_baffle.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for secondary_baffle model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: secondary_baffle
 description: |-
   Defines a baffle around the secondary mirror to keep NSB light from

--- a/schemas/secondary_shadow_diameter.schema.yml
+++ b/schemas/secondary_shadow_diameter.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for secondary_shadow_diameter model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: secondary_shadow_diameter
 description: |-
   The diameter of any non-reflective but not transparent (black)

--- a/schemas/secondary_shadow_offset.schema.yml
+++ b/schemas/secondary_shadow_offset.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for secondary_shadow_offset model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: secondary_shadow_offset
 description: |-
   The secondary mirror shadowing element is normally assumed at the level

--- a/schemas/telescope_axes_height.schema.yml
+++ b/schemas/telescope_axes_height.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for telescope_axes_height model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: telescope_axes_height
 description: Height of telescope axes above ground level.
 data:

--- a/schemas/telescope_random_angle.schema.yml
+++ b/schemas/telescope_random_angle.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for telescope_random_angle model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: telescope_random_angle
 description: |-
   Random (known) misalignment of the telescope in each axis

--- a/schemas/telescope_random_error.schema.yml
+++ b/schemas/telescope_random_error.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for telescope_random_error model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: telescope_random_error
 description: |-
   Random (unknown) alignment error of the telescope in each axis

--- a/schemas/telescope_sphere_radius.schema.yml
+++ b/schemas/telescope_sphere_radius.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for telescope_sphere_radius model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: telescope_sphere_radius
 developer_note: |-
   Part of `array_coordinates` in CORSIKA.

--- a/schemas/telescope_transmission.schema.yml
+++ b/schemas/telescope_transmission.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for telescope_transmission model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: telescope_transmission
 developer_note: |-
   If compiled with the \texttt{RAYTRACING_INTERSECT_RODS} pre-processor

--- a/schemas/teltrig_min_sigsum.schema.yml
+++ b/schemas/teltrig_min_sigsum.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for teltrig_min_sigsum model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: teltrig_min_sigsum
 description: |-
   Minimum signal sum at sector trigger over threshold.

--- a/schemas/teltrig_min_time.schema.yml
+++ b/schemas/teltrig_min_time.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for teltrig_min_time model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: teltrig_min_time
 description: Minimum time of sector trigger over threshold.
 instrument:

--- a/schemas/transit_time_calib_error.schema.yml
+++ b/schemas/transit_time_calib_error.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for transit_time_calib_error model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: transit_time_calib_error
 description: |-
   Accuracy with which the actual signal delay due to transit

--- a/schemas/transit_time_compensate_error.schema.yml
+++ b/schemas/transit_time_compensate_error.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for transit_time_compensate_error model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: transit_time_compensate_error
 description: |-
   Additional error (r.m.s.) in how well the number of steps for

--- a/schemas/transit_time_compensate_step.schema.yml
+++ b/schemas/transit_time_compensate_step.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for transit_time_compensate_step model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: transit_time_compensate_step
 description: |-
   If signal delays can be compensated independent of the sampling,

--- a/schemas/transit_time_error.schema.yml
+++ b/schemas/transit_time_error.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for transit_time_error model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: transit_time_error
 short_description: Errors (r.m.s.) in transit time, not related to high voltage.
 description: |-

--- a/schemas/transit_time_jitter.schema.yml
+++ b/schemas/transit_time_jitter.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for transit_time_jitter model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: transit_time_jitter
 description: |-
   Time jitter (Gaussian r.m.s. spread of random fluctuations) of individual

--- a/schemas/trigger_current_limit.schema.yml
+++ b/schemas/trigger_current_limit.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for trigger_current_limit model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: trigger_current_limit
 description: Pixels above this limit are excluded from the trigger.
 instrument:

--- a/schemas/trigger_decision_circuitry.schema.yml
+++ b/schemas/trigger_decision_circuitry.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for trigger_decision_circuitry model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: trigger_decision_circuitry
 developer_note: |-
   Part of sim_telarray camera configuration file (TRIGGER lines).

--- a/schemas/trigger_delay_compensation.schema.yml
+++ b/schemas/trigger_delay_compensation.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for trigger_delay_compensation model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: trigger_delay_compensation
 developer_note: Always zero for all cameras.
 description: |-

--- a/schemas/trigger_pixels.schema.yml
+++ b/schemas/trigger_pixels.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for trigger_pixels model parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: trigger_pixels
 description: |-
   Number of pixels required for single telescope trigger.


### PR DESCRIPTION
rename in all schemas the key `base_schema` to `meta_schema` (as we have learned that the schema of a schema is called meta_schema.